### PR TITLE
Handle auth login callback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +327,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,6 +578,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -952,6 +980,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
 name = "reqwest"
 version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,7 +1201,9 @@ dependencies = [
  "anyhow",
  "axum",
  "clap",
+ "env_logger",
  "graphql_client",
+ "log",
  "reqwest",
  "serde",
  "serde_json",
@@ -1223,6 +1282,15 @@ dependencies = [
  "redox_syscall",
  "rustix",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +454,17 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -880,6 +912,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,7 +935,7 @@ checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "smallvec",
  "windows-targets 0.48.2",
 ]
@@ -972,11 +1010,31 @@ checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall 0.2.16",
+ "thiserror",
 ]
 
 [[package]]
@@ -1201,6 +1259,7 @@ dependencies = [
  "anyhow",
  "axum",
  "clap",
+ "dirs",
  "env_logger",
  "graphql_client",
  "log",
@@ -1279,7 +1338,7 @@ checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
  "windows-sys 0.48.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,6 +1273,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tower-http",
+ "urlencoding",
  "webbrowser",
 ]
 
@@ -1458,6 +1466,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+dependencies = [
+ "bitflags 2.4.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1536,6 +1562,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 anyhow = "1.0.75"
 axum = "0.6"
 clap = { version = "4.2", features = ["derive"] }
+dirs = "5"
 env_logger = "0.10"
 graphql_client = "0.13.0"
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ reqwest = { version = "0.11.20", features = ["json"] }
 serde = "1"
 serde_json = "1"
 tokio = { version = "1.18.2", features = ["full", "sync"] }
+tower-http = "0.4"
+urlencoding = "2"
 webbrowser = "0.8"
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,9 @@ edition = "2021"
 anyhow = "1.0.75"
 axum = "0.6"
 clap = { version = "4.2", features = ["derive"] }
+env_logger = "0.10"
 graphql_client = "0.13.0"
+log = "0.4"
 reqwest = { version = "0.11.20", features = ["json"] }
 serde = "1"
 serde_json = "1"

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -10,8 +10,8 @@ impl Browser {
         //   - state?
         //   - PKCE?
         let url = format!(
-            "https:/x.cartridge.gg/auth?redirect_url=http://{redirect_url}",
-            redirect_url = local_addr,
+            "https:/x.cartridge.gg/auth?redirect_uri=http://{redirect_uri}/callback",
+            redirect_uri = local_addr,
         );
 
         println!("Your browser has been opened to visit: \n\n    {url}\n");

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -5,14 +5,8 @@ pub struct Browser;
 
 impl Browser {
     pub async fn open(local_addr: &SocketAddr) -> Result<()> {
-        // TODO:
-        //   - client_id?
-        //   - state?
-        //   - PKCE?
-        let url = format!(
-            "https:/x.cartridge.gg/auth?redirect_uri=http://{redirect_uri}/callback",
-            redirect_uri = local_addr,
-        );
+        let callback_uri = format!("http://{local_addr}/callback");
+        let url = format!("https:/x.cartridge.gg/slot/auth?callback_uri={callback_uri}");
 
         println!("Your browser has been opened to visit: \n\n    {url}\n");
         webbrowser::open(&url)?;

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -1,12 +1,14 @@
 use anyhow::Result;
 use std::net::SocketAddr;
+use urlencoding::encode;
 
 pub struct Browser;
 
 impl Browser {
     pub async fn open(local_addr: &SocketAddr) -> Result<()> {
-        let callback_uri = format!("http://{local_addr}/callback");
-        let url = format!("https:/x.cartridge.gg/slot/auth?callback_uri={callback_uri}");
+        let callback_uri = format!("http://{local_addr}/callback").replace("[::1]", "localhost");
+        let encoded_callback_uri = encode(&callback_uri);
+        let url = format!("https:/x.cartridge.gg/slot/auth?callback_uri={encoded_callback_uri}");
 
         println!("Your browser has been opened to visit: \n\n    {url}\n");
         webbrowser::open(&url)?;

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -14,7 +14,7 @@ impl Browser {
             redirect_url = local_addr,
         );
 
-        println!("Your browser has been opened to visit: \n\n    {url}");
+        println!("Your browser has been opened to visit: \n\n    {url}\n");
         webbrowser::open(&url)?;
 
         Ok(())

--- a/src/command/auth.rs
+++ b/src/command/auth.rs
@@ -25,9 +25,9 @@ impl Auth {
 
         let handler = std::thread::spawn(move || {
             let server = LocalServer::new().expect("Failed to start a server");
-            let addr = &server.local_addr().unwrap();
+            let addr = server.local_addr().unwrap();
 
-            let res = rt.block_on(async { tokio::join!(server.start(), Browser::open(addr)) });
+            let res = rt.block_on(async { tokio::join!(server.start(), Browser::open(&addr)) });
 
             match res {
                 (Err(e), _) => {

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -1,0 +1,3 @@
+// TODO: env instead?
+pub const CARTRIDGE_API_URL: &str = "https://api.cartridge.gg/";
+pub const CARTRIDGE_KEYCHAIN_URL: &str = "https://x.cartridge.gg/";

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod browser;
 mod cli;
 mod command;
+mod constant;
 mod server;
 
 use clap::Parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,15 +5,17 @@ mod server;
 
 use clap::Parser;
 use cli::Cli;
+use log::error;
 
 #[tokio::main]
 async fn main() {
+    env_logger::init();
     let cli = Cli::parse();
 
     match &cli.command.run().await {
         Ok(_) => {}
         Err(e) => {
-            eprintln!("{e}")
+            error!("{e}")
         }
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -56,11 +56,11 @@ impl<'a> LocalServer {
 
     async fn callback(
         State(state): State<Arc<AppState>>,
-        Query(params): Query<CallbackParams>,
+        Json(payload): Json<CallbackPayload>,
     ) -> Result<Json<Value>, AppError> {
         state.shutdown().await?;
 
-        match params.code {
+        match payload.code {
             Some(code) => {
                 println!("auth_code: {}", code);
 
@@ -80,7 +80,7 @@ impl<'a> LocalServer {
 }
 
 #[derive(Deserialize)]
-struct CallbackParams {
+struct CallbackPayload {
     code: Option<String>,
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,9 +6,10 @@ use axum::{
     routing::post,
     Json, Router,
 };
+use log::error;
+use serde::Deserialize;
 use serde_json::{json, Value};
 use std::{
-    collections::HashMap,
     net::{SocketAddr, TcpListener},
     sync::Arc,
 };
@@ -55,17 +56,32 @@ impl<'a> LocalServer {
 
     async fn callback(
         State(state): State<Arc<AppState>>,
-        Query(params): Query<HashMap<String, String>>,
+        Query(params): Query<CallbackParams>,
     ) -> Result<Json<Value>, AppError> {
-        let auth_code = &params["code"];
-        println!("auth_code: {auth_code}");
-
-        // TODO: get access token using the authorization code
-
         state.shutdown().await?;
 
-        Ok(Json(json!({ "success": true })))
+        match params.code {
+            Some(code) => {
+                println!("auth_code: {}", code);
+
+                // TODO: 1. Get access token using the authorization code
+
+                // TODO: 2. Store the access token locally
+
+                Ok(Json(json!({ "success": true })))
+            }
+            None => {
+                error!("User denied consent. Try again.");
+
+                Ok(Json(json!({ "success": true })))
+            }
+        }
     }
+}
+
+#[derive(Deserialize)]
+struct CallbackParams {
+    code: Option<String>,
 }
 
 #[derive(Clone)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -13,7 +13,6 @@ use std::{
     fs::{self, OpenOptions},
     io::Write,
     net::{SocketAddr, TcpListener},
-    path::Path,
     sync::Arc,
 };
 use tokio::sync::mpsc::{Receiver, Sender};
@@ -78,7 +77,9 @@ impl<'a> LocalServer {
                     .await?;
 
                 // 2. Store the access token locally
-                let file_path = Path::new("~/.config/slot/credentails.json");
+                let mut file_path = dirs::config_local_dir().unwrap();
+
+                file_path.push("slot/credentails.json");
                 fs::create_dir_all(file_path.parent().unwrap())?;
 
                 // Create or overwrite credentails if the file already exists


### PR DESCRIPTION
## Authorization Flow

### General

1. Run `slot auth login` on terminal
1. Start local server with `0.0.0.0:0/callback` endpoint
1. Open https://x.cartridge.gg/slot/auth with `callback_uri` param
1. User login/signup in the browser or redirect to consent page if controller already exists
1. User either authorise or deny the consent

### When authorized
1. Redirect to `api.cartridge.gg/oauth2/auth?client_id=cartridge&redirect_uri=<success-uri>&state=<callback-uri>`
1. The server redirects to `x.cartridge.gg/slot/auth/success` with code param
1. Send a post request to callback endpoint with code param
1. Shutdown the local server
1. Send post request to `api.cartridge.gg/oauth2/token` endpoint with the code just retrieved
1. Save token locally as `<dirs::config_local_dir()>/slot/credentials.json`
1. Console out success message

### When denied
1. Redirect to `/slot/auth/failure`
1. Send a post request to the callback endpoint without code param
1. Shutdown the local server
1. Console out `User denied` error message

### Tasks
- Success path
  - [x] Request token
  - [x] Save token
- [x] Denial path
  - When `code` param is empty on `/callback` endpoint
  - Stop server
  - Return successfully denied json response
- [x] Setup log and env_logger
