### PR TITLE
Support fork deployment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2053,6 +2053,7 @@ dependencies = [
  "tokio",
  "tower-http",
  "tracing",
+ "url",
  "urlencoding",
  "webbrowser",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ tracing = "0.1.34"
 urlencoding = "2"
 webbrowser = "0.8"
 starknet = "0.6.0"
+url = "2.2.2"
 
 [[bin]]
 name = "slot"

--- a/schema.json
+++ b/schema.json
@@ -18357,6 +18357,114 @@
                   "ofType": null
                 }
               }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "blockTime",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "forkRpcUrl",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "forkBlockNumber",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Long",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "accounts",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "invokeMaxSteps",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Long",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "validateMaxSteps",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Long",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "disableFee",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "gasPrice",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Long",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "chainId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             }
           ],
           "inputFields": [],
@@ -19258,6 +19366,85 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "name",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "forkName",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "forkBlockNumber",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Long",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "tier",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "DeploymentTier",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "wait",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "forkDeployment",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "UNION",
+                  "name": "DeploymentConfig",
                   "ofType": null
                 }
               }
@@ -36875,6 +37062,26 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Int",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "forkRpcUrl",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "forkBlockNumber",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Long",
                 "ofType": null
               }
             },

--- a/src/api.rs
+++ b/src/api.rs
@@ -47,7 +47,9 @@ impl ApiClient {
             .map_err(ApiError::ReqwestError)?;
 
         if res.status() == 403 {
-            return Err(ApiError::CredentialsError(anyhow::anyhow!("Invalid token, authenticate with `slot auth login`")));
+            return Err(ApiError::CredentialsError(anyhow::anyhow!(
+                "Invalid token, authenticate with `slot auth login`"
+            )));
         }
 
         let res: Response<R> = res.json().await.map_err(ApiError::ReqwestError)?;

--- a/src/command/deployments/create.rs
+++ b/src/command/deployments/create.rs
@@ -13,9 +13,7 @@ use crate::{
     },
 };
 
-use super::services::CreateServiceCommands;
-
-type Long = u64;
+use super::{services::CreateServiceCommands, Long, Tier};
 
 #[derive(GraphQLQuery)]
 #[graphql(
@@ -24,11 +22,6 @@ type Long = u64;
     response_derives = "Debug"
 )]
 pub struct CreateDeployment;
-
-#[derive(clap::ValueEnum, Clone, Debug, serde::Serialize)]
-pub enum Tier {
-    Basic,
-}
 
 #[derive(Debug, Args)]
 #[command(next_help_heading = "Create options")]

--- a/src/command/deployments/fork.graphql
+++ b/src/command/deployments/fork.graphql
@@ -1,0 +1,20 @@
+mutation ForkDeployment(
+  $project: String!
+  $forkName: String!
+  $forkBlockNumber: Long!
+  $tier: DeploymentTier!
+  $wait: Boolean
+) {
+  forkDeployment(
+    name: $project
+    forkName: $forkName
+    forkBlockNumber: $forkBlockNumber
+    tier: $tier
+    wait: $wait
+  ) {
+    __typename
+    ... on KatanaConfig {
+      rpc
+    }
+  }
+}

--- a/src/command/deployments/fork.rs
+++ b/src/command/deployments/fork.rs
@@ -1,0 +1,97 @@
+#![allow(clippy::enum_variant_names)]
+
+use anyhow::Result;
+use clap::Args;
+use graphql_client::{GraphQLQuery, Response};
+use starknet::providers::{jsonrpc::HttpTransport, JsonRpcClient, Provider};
+use url::Url;
+
+use crate::{
+    api::ApiClient,
+    command::deployments::fork::fork_deployment::{
+        DeploymentTier, ForkDeploymentForkDeployment::KatanaConfig, Variables,
+    },
+};
+
+use super::{services::ForkServiceCommands, Long, Tier};
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "schema.json",
+    query_path = "src/command/deployments/fork.graphql",
+    response_derives = "Debug"
+)]
+pub struct ForkDeployment;
+
+#[derive(Debug, Args)]
+#[command(next_help_heading = "Fork options")]
+pub struct ForkArgs {
+    #[arg(help = "The name of the project to fork.")]
+    pub project: String,
+    #[arg(short, long, default_value = "basic")]
+    #[arg(value_name = "tier")]
+    #[arg(help = "Deployment tier.")]
+    pub tier: Tier,
+
+    #[command(subcommand)]
+    fork_commands: ForkServiceCommands,
+}
+
+impl ForkArgs {
+    pub async fn run(&self) -> Result<()> {
+        let (fork_name, fork_block_number) = self.fork_config().await?;
+
+        let tier = match &self.tier {
+            Tier::Basic => DeploymentTier::basic,
+        };
+
+        let request_body = ForkDeployment::build_query(Variables {
+            project: self.project.clone(),
+            fork_name: fork_name.clone(),
+            fork_block_number,
+            tier,
+            wait: Some(true),
+        });
+
+        let client = ApiClient::new();
+        let res: Response<fork_deployment::ResponseData> = client.post(&request_body).await?;
+        if let Some(errors) = res.errors.clone() {
+            for err in errors {
+                println!("Error: {}", err.message);
+            }
+        }
+
+        if let Some(data) = res.data {
+            println!("Fork success 🚀");
+            if let KatanaConfig(config) = data.fork_deployment {
+                println!("\nEndpoints:");
+                println!("  RPC: {}", config.rpc);
+                println!(
+                    "\nStream logs with `slot deployments logs {} katana -f`",
+                    fork_name
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn fork_config(&self) -> Result<(String, u64)> {
+        match &self.fork_commands {
+            ForkServiceCommands::Katana(config) => {
+                let block_number = if let Some(block_number) = config.fork_block_number {
+                    block_number
+                } else {
+                    // Workaround to get latest block number. Perhaps Katana could default to latest if none is supplied
+                    let rpc_client = JsonRpcClient::new(HttpTransport::new(Url::parse(&format!(
+                        "https://api.cartridge.gg/x/{}/katana",
+                        self.project
+                    ))?));
+                    rpc_client.block_number().await?
+                };
+
+                Ok((config.fork_name.clone(), block_number))
+            }
+        }
+    }
+}

--- a/src/command/deployments/mod.rs
+++ b/src/command/deployments/mod.rs
@@ -2,17 +2,20 @@ use anyhow::Result;
 use clap::Subcommand;
 
 use self::{
-    create::CreateArgs, delete::DeleteArgs, describe::DescribeArgs, list::ListArgs, logs::LogsArgs,
-    update::UpdateArgs,
+    create::CreateArgs, delete::DeleteArgs, describe::DescribeArgs, fork::ForkArgs, list::ListArgs,
+    logs::LogsArgs, update::UpdateArgs,
 };
 
 mod create;
 mod delete;
 mod describe;
+mod fork;
 mod list;
 mod logs;
 mod services;
 mod update;
+
+type Long = u64;
 
 #[derive(Subcommand, Debug)]
 pub enum Deployments {
@@ -22,6 +25,8 @@ pub enum Deployments {
     Delete(DeleteArgs),
     #[command(about = "Update a deployment.")]
     Update(UpdateArgs),
+    #[command(about = "Fork a deployment.")]
+    Fork(ForkArgs),
     #[command(about = "Describe a deployment's configuration.")]
     Describe(DescribeArgs),
     #[command(about = "List all deployments.", aliases = ["ls"])]
@@ -36,9 +41,15 @@ impl Deployments {
             Deployments::Create(args) => args.run().await,
             Deployments::Delete(args) => args.run().await,
             Deployments::Update(args) => args.run().await,
+            Deployments::Fork(args) => args.run().await,
             Deployments::Describe(args) => args.run().await,
             Deployments::List(args) => args.run().await,
             Deployments::Logs(args) => args.run().await,
         }
     }
+}
+
+#[derive(clap::ValueEnum, Clone, Debug, serde::Serialize)]
+pub enum Tier {
+    Basic,
 }

--- a/src/command/deployments/services/katana.rs
+++ b/src/command/deployments/services/katana.rs
@@ -59,6 +59,14 @@ pub struct KatanaUpdateArgs {
     #[arg(help = "Block time.")]
     pub block_time: Option<i64>,
 
+    #[arg(long, short, value_name = "fork_rpc_url")]
+    #[arg(help = "Fork RPC URL.")]
+    pub fork_rpc_url: Option<String>,
+
+    #[arg(long, short, value_name = "fork_block_number")]
+    #[arg(help = "Fork Block Number.")]
+    pub fork_block_number: Option<u64>,
+
     #[arg(long, value_name = "invoke_max_steps")]
     #[arg(help = "Invoke Max Steps.")]
     pub invoke_max_steps: Option<u64>,
@@ -74,4 +82,15 @@ pub struct KatanaUpdateArgs {
     #[arg(long, value_name = "gas_price")]
     #[arg(help = "Gas Price.")]
     pub gas_price: Option<u64>,
+}
+
+#[derive(Debug, Args, serde::Serialize)]
+#[command(next_help_heading = "Katana fork options")]
+pub struct KatanaForkArgs {
+    #[arg(long, value_name = "fork_name")]
+    #[arg(help = "Specify the fork name")]
+    pub fork_name: String,
+    #[arg(long, value_name = "fork_block_number")]
+    #[arg(help = "Specify block number to fork. (latests if not provided)")]
+    pub fork_block_number: Option<u64>,
 }

--- a/src/command/deployments/services/mod.rs
+++ b/src/command/deployments/services/mod.rs
@@ -1,7 +1,7 @@
 use clap::{Subcommand, ValueEnum};
 
 use self::{
-    katana::{KatanaCreateArgs, KatanaUpdateArgs},
+    katana::{KatanaCreateArgs, KatanaForkArgs, KatanaUpdateArgs},
     torii::{ToriiCreateArgs, ToriiUpdateArgs},
 };
 
@@ -25,6 +25,15 @@ pub enum UpdateServiceCommands {
     Katana(KatanaUpdateArgs),
     #[command(about = "Torii deployment.")]
     Torii(ToriiUpdateArgs),
+}
+
+#[derive(Debug, Subcommand, serde::Serialize)]
+#[serde(untagged)]
+pub enum ForkServiceCommands {
+    #[command(about = "Katana deployment.")]
+    Katana(KatanaForkArgs),
+    // #[command(about = "Torii deployment.")]
+    // Torii(ToriiUpdateArgs),
 }
 
 #[derive(Clone, Debug, ValueEnum, serde::Serialize)]

--- a/src/command/deployments/update.rs
+++ b/src/command/deployments/update.rs
@@ -54,6 +54,8 @@ impl UpdateArgs {
                 config: Some(UpdateServiceConfigInput {
                     katana: Some(UpdateKatanaConfigInput {
                         block_time: config.block_time,
+                        fork_rpc_url: config.fork_rpc_url.clone(),
+                        fork_block_number: config.fork_block_number,
                         disable_fee: config.disable_fee,
                         gas_price: config.gas_price,
                         invoke_max_steps: config.invoke_max_steps,


### PR DESCRIPTION
Support forking command to fork a katana service, copies katana configs in the fork. If the service is owned by user the seed will also be copied. 

If fork_block_number is not provided we query for latest block and use that

`slot deployments fork {project} {service} --fork-name {name} --fork-block-number {number}`