### PR TITLE
Implement retrieving predeployed accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4414,6 +4414,7 @@ version = "0.5.9"
 dependencies = [
  "anyhow",
  "axum",
+ "base64 0.21.3",
  "chrono",
  "clap",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ katana-primitives = { git = "https://github.com/dojoengine/dojo", rev = "c83936"
 ] }
 anyhow = "1.0.75"
 axum = "0.6"
+base64 = "0.21.2"
 clap = { version = "4.2", features = ["derive"] }
 chrono = "0.4.31"
 ctrlc = "3.4.1"

--- a/schema.json
+++ b/schema.json
@@ -11569,7 +11569,7 @@
             },
             {
               "defaultValue": null,
-              "description": "Base64 encoded genesis file with all the classes embedded in the file itself (if any).",
+              "description": null,
               "name": "genesis",
               "type": {
                 "kind": "SCALAR",
@@ -11865,6 +11865,22 @@
                 "ofType": {
                   "kind": "ENUM",
                   "name": "DeploymentTier",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "region",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               }
@@ -12980,6 +12996,152 @@
                     "ofType": null
                   }
                 }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "region field predicates",
+              "name": "region",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "regionNEQ",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "regionIn",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "regionNotIn",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "regionGT",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "regionGTE",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "regionLT",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "regionLTE",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "regionContains",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "regionHasPrefix",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "regionHasSuffix",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "regionEqualFold",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "regionContainsFold",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             },
             {
@@ -18401,6 +18563,34 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Long",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "seed",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "genesis",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },

--- a/src/command/deployments/accounts.graphql
+++ b/src/command/deployments/accounts.graphql
@@ -1,0 +1,15 @@
+query KatanaAccounts($project: String!) {
+  deployment(name: $project, service: katana) {
+    project
+    branch
+    tier
+    config {
+      __typename
+      ... on KatanaConfig {
+        seed
+        genesis
+        accounts
+      }
+    }
+  }
+}

--- a/src/command/deployments/accounts.rs
+++ b/src/command/deployments/accounts.rs
@@ -1,0 +1,142 @@
+#![allow(clippy::enum_variant_names)]
+
+use anyhow::Result;
+use base64::prelude::*;
+use clap::Args;
+use graphql_client::{GraphQLQuery, Response};
+use katana_primitives::contract::ContractAddress;
+use katana_primitives::genesis::allocation::DevAllocationsGenerator;
+use katana_primitives::genesis::Genesis;
+use katana_primitives::genesis::{allocation::GenesisAccountAlloc, json::GenesisJson};
+use std::str::FromStr;
+
+use crate::api::ApiClient;
+
+use super::services::KatanaAccountCommands;
+
+use self::katana_accounts::{
+    KatanaAccountsDeploymentConfig::KatanaConfig, ResponseData, Variables,
+};
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "schema.json",
+    query_path = "src/command/deployments/accounts.graphql",
+    response_derives = "Debug"
+)]
+pub struct KatanaAccounts;
+
+#[derive(Debug, Args)]
+#[command(next_help_heading = "Accounts options")]
+pub struct AccountsArgs {
+    #[arg(help = "The name of the project.")]
+    pub project: String,
+
+    #[command(subcommand)]
+    accounts_commands: KatanaAccountCommands,
+}
+
+impl AccountsArgs {
+    pub async fn run(&self) -> Result<()> {
+        let request_body = KatanaAccounts::build_query(Variables {
+            project: self.project.clone(),
+        });
+
+        let client = ApiClient::new();
+        let res: Response<ResponseData> = client.post(&request_body).await?;
+        if let Some(errors) = res.errors.clone() {
+            for err in errors {
+                println!("Error: {}", err.message);
+            }
+        }
+
+        if let Some(data) = res.data {
+            if let Some(deployment) = data.deployment {
+                if let KatanaConfig(config) = deployment.config {
+                    // genesis overrides seed
+                    if let Some(genesis) = config.genesis {
+                        let decoded = BASE64_STANDARD.decode(genesis)?;
+                        let json = GenesisJson::from_str(&String::from_utf8(decoded)?)?;
+                        let genesis = Genesis::try_from(json)?;
+                        print_genesis_accounts(genesis.accounts().peekable(), None);
+
+                        return Ok(());
+                    }
+
+                    if !config.seed.is_empty() {
+                        let total = match config.accounts {
+                            Some(accounts) => accounts as u16,
+                            None => 10,
+                        };
+
+                        let accounts = DevAllocationsGenerator::new(total)
+                            .with_seed(parse_seed(&config.seed))
+                            .generate();
+                          
+                        let mut genesis = Genesis::default();
+                        genesis
+                            .extend_allocations(accounts.into_iter().map(|(k, v)| (k, v.into())));
+                        print_genesis_accounts(genesis.accounts().peekable(), Some(&config.seed));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn print_genesis_accounts<'a, Accounts>(accounts: Accounts, seed: Option<&str>)
+where
+    Accounts: Iterator<Item = (&'a ContractAddress, &'a GenesisAccountAlloc)>,
+{
+    println!(
+        r"
+
+PREFUNDED ACCOUNTS
+=================="
+    );
+
+    for (addr, account) in accounts {
+        if let Some(pk) = account.private_key() {
+            println!(
+                r"
+| Account address |  {addr}
+| Private key     |  {pk:#x}
+| Public key      |  {:#x}",
+                account.public_key()
+            )
+        } else {
+            println!(
+                r"
+| Account address |  {addr}
+| Public key      |  {:#x}",
+                account.public_key()
+            )
+        }
+    }
+
+    if let Some(seed) = seed {
+    println!(
+      r"
+ACCOUNTS SEED
+=============
+{seed}
+"
+  );
+    }
+}
+
+fn parse_seed(seed: &str) -> [u8; 32] {
+    let seed = seed.as_bytes();
+
+    if seed.len() >= 32 {
+        unsafe { *(seed[..32].as_ptr() as *const [u8; 32]) }
+    } else {
+        let mut actual_seed = [0u8; 32];
+        seed.iter()
+            .enumerate()
+            .for_each(|(i, b)| actual_seed[i] = *b);
+        actual_seed
+    }
+}

--- a/src/command/deployments/mod.rs
+++ b/src/command/deployments/mod.rs
@@ -2,10 +2,11 @@ use anyhow::Result;
 use clap::Subcommand;
 
 use self::{
-    create::CreateArgs, delete::DeleteArgs, describe::DescribeArgs, fork::ForkArgs, list::ListArgs,
-    logs::LogsArgs, update::UpdateArgs,
+    accounts::AccountsArgs, create::CreateArgs, delete::DeleteArgs, describe::DescribeArgs,
+    fork::ForkArgs, list::ListArgs, logs::LogsArgs, update::UpdateArgs,
 };
 
+mod accounts;
 mod create;
 mod delete;
 mod describe;
@@ -33,6 +34,8 @@ pub enum Deployments {
     List(ListArgs),
     #[command(about = "Fetch logs for a deployment.")]
     Logs(LogsArgs),
+    #[command(about = "Fetch Katana accounts.")]
+    Accounts(AccountsArgs),
 }
 
 impl Deployments {
@@ -45,6 +48,7 @@ impl Deployments {
             Deployments::Describe(args) => args.run().await,
             Deployments::List(args) => args.run().await,
             Deployments::Logs(args) => args.run().await,
+            Deployments::Accounts(args) => args.run().await,
         }
     }
 }

--- a/src/command/deployments/services/katana.rs
+++ b/src/command/deployments/services/katana.rs
@@ -104,6 +104,10 @@ pub struct KatanaForkArgs {
     pub fork_block_number: Option<u64>,
 }
 
+#[derive(Debug, Args, serde::Serialize)]
+#[command(next_help_heading = "Katana account options")]
+pub struct KatanaAccountArgs {}
+
 fn genesis_value_parser(path: &str) -> Result<String, anyhow::Error> {
     let path = PathBuf::from(shellexpand::full(path)?.into_owned());
     let genesis = GenesisJson::load(path)?;

--- a/src/command/deployments/services/mod.rs
+++ b/src/command/deployments/services/mod.rs
@@ -1,7 +1,7 @@
 use clap::{Subcommand, ValueEnum};
 
 use self::{
-    katana::{KatanaCreateArgs, KatanaForkArgs, KatanaUpdateArgs},
+    katana::{KatanaAccountArgs, KatanaCreateArgs, KatanaForkArgs, KatanaUpdateArgs},
     torii::{ToriiCreateArgs, ToriiUpdateArgs},
 };
 
@@ -34,6 +34,13 @@ pub enum ForkServiceCommands {
     Katana(KatanaForkArgs),
     // #[command(about = "Torii deployment.")]
     // Torii(ToriiUpdateArgs),
+}
+
+#[derive(Debug, Subcommand, serde::Serialize)]
+#[serde(untagged)]
+pub enum KatanaAccountCommands {
+    #[command(about = "Katana deployment.")]
+    Katana(KatanaAccountArgs),
 }
 
 #[derive(Clone, Debug, ValueEnum, serde::Serialize)]


### PR DESCRIPTION
Resolves https://github.com/cartridge-gg/slot/issues/18

`slot deployments accounts project_name katana` dumps either the predeployed from genesis OR the ones generated from seed. Print format is the same as katana startup