### PR TITLE
refactor: extra account info in credentials

### DIFF
--- a/src/command/auth/info.graphql
+++ b/src/command/auth/info.graphql
@@ -1,7 +1,12 @@
 query Me {
     me {
         id
-        contractAddress
         name
+        contractAddress
+        credentials {
+            webauthn {
+                publicKey
+            }
+        }
     }
 }

--- a/src/command/auth/info.rs
+++ b/src/command/auth/info.rs
@@ -17,11 +17,12 @@ pub struct Me;
 pub struct InfoArgs {}
 
 impl InfoArgs {
+    // TODO: find the account info from `credentials.json` first before making a request
     pub async fn run(&self) -> Result<()> {
         let request_body = Me::build_query(Variables {});
 
-        let client = ApiClient::new();
-        let res: Response<ResponseData> = client.post(&request_body).await?;
+        let client = Client::new();
+        let res: Response<ResponseData> = client.query(&request_body).await?;
         if let Some(errors) = res.errors {
             for err in errors {
                 println!("Error: {}", err.message);

--- a/src/command/auth/info.rs
+++ b/src/command/auth/info.rs
@@ -3,7 +3,7 @@ use clap::Args;
 use graphql_client::{GraphQLQuery, Response};
 use me::{ResponseData, Variables};
 
-use crate::api::Client;
+use crate::{api::Client, credential::Credentials};
 
 #[derive(GraphQLQuery)]
 #[graphql(
@@ -19,10 +19,12 @@ pub struct InfoArgs {}
 impl InfoArgs {
     // TODO: find the account info from `credentials.json` first before making a request
     pub async fn run(&self) -> Result<()> {
-        let request_body = Me::build_query(Variables {});
+        let credentials = Credentials::load()?;
+        let client = Client::new_with_token(credentials.access_token);
 
-        let client = Client::new();
+        let request_body = Me::build_query(Variables {});
         let res: Response<ResponseData> = client.query(&request_body).await?;
+
         if let Some(errors) = res.errors {
             for err in errors {
                 println!("Error: {}", err.message);

--- a/src/command/auth/info.rs
+++ b/src/command/auth/info.rs
@@ -1,16 +1,15 @@
 use anyhow::Result;
 use clap::Args;
 use graphql_client::{GraphQLQuery, Response};
+use me::{ResponseData, Variables};
 
-use crate::api::ApiClient;
-
-use self::me::{ResponseData, Variables};
+use crate::api::Client;
 
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "schema.json",
     query_path = "src/command/auth/info.graphql",
-    response_derives = "Debug"
+    response_derives = "Debug, Clone, Serialize"
 )]
 pub struct Me;
 

--- a/src/command/auth/mod.rs
+++ b/src/command/auth/mod.rs
@@ -3,7 +3,7 @@ use clap::Subcommand;
 
 use self::{info::InfoArgs, login::LoginArgs};
 
-mod info;
+pub mod info;
 mod login;
 
 #[derive(Subcommand, Debug)]

--- a/src/command/deployments/accounts.rs
+++ b/src/command/deployments/accounts.rs
@@ -10,7 +10,8 @@ use katana_primitives::genesis::Genesis;
 use katana_primitives::genesis::{allocation::GenesisAccountAlloc, json::GenesisJson};
 use std::str::FromStr;
 
-use crate::api::ApiClient;
+use crate::api::Client;
+use crate::credential::Credentials;
 
 use super::services::KatanaAccountCommands;
 
@@ -42,8 +43,10 @@ impl AccountsArgs {
             project: self.project.clone(),
         });
 
-        let client = ApiClient::new();
-        let res: Response<ResponseData> = client.post(&request_body).await?;
+        let user = Credentials::load()?;
+        let client = Client::new_with_token(user.access_token);
+
+        let res: Response<ResponseData> = client.query(&request_body).await?;
         if let Some(errors) = res.errors.clone() {
             for err in errors {
                 println!("Error: {}", err.message);

--- a/src/command/deployments/create.rs
+++ b/src/command/deployments/create.rs
@@ -5,12 +5,13 @@ use clap::Args;
 use graphql_client::{GraphQLQuery, Response};
 
 use crate::{
-    api::ApiClient,
+    api::Client,
     command::deployments::create::create_deployment::{
         CreateDeploymentCreateDeployment::{KatanaConfig, MadaraConfig, ToriiConfig},
         CreateKatanaConfigInput, CreateMadaraConfigInput, CreateServiceConfigInput,
         CreateServiceInput, CreateToriiConfigInput, DeploymentService, DeploymentTier, Variables,
     },
+    credential::Credentials,
 };
 
 use super::{services::CreateServiceCommands, Long, Tier};
@@ -104,8 +105,10 @@ impl CreateArgs {
             wait: Some(true),
         });
 
-        let client = ApiClient::new();
-        let res: Response<create_deployment::ResponseData> = client.post(&request_body).await?;
+        let user = Credentials::load()?;
+        let client = Client::new_with_token(user.access_token);
+
+        let res: Response<create_deployment::ResponseData> = client.query(&request_body).await?;
         if let Some(errors) = res.errors.clone() {
             for err in errors {
                 println!("Error: {}", err.message);

--- a/src/command/deployments/delete.rs
+++ b/src/command/deployments/delete.rs
@@ -5,8 +5,9 @@ use clap::Args;
 use graphql_client::{GraphQLQuery, Response};
 
 use crate::{
-    api::ApiClient,
+    api::Client,
     command::deployments::delete::delete_deployment::{DeploymentService, Variables},
+    credential::Credentials,
 };
 
 #[derive(GraphQLQuery)]
@@ -47,8 +48,10 @@ impl DeleteArgs {
             service,
         });
 
-        let client = ApiClient::new();
-        let res: Response<delete_deployment::ResponseData> = client.post(&request_body).await?;
+        let user = Credentials::load()?;
+        let client = Client::new_with_token(user.access_token);
+
+        let res: Response<delete_deployment::ResponseData> = client.query(&request_body).await?;
         if let Some(errors) = res.errors.clone() {
             for err in errors {
                 println!("Error: {}", err.message);

--- a/src/command/deployments/describe.rs
+++ b/src/command/deployments/describe.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use clap::Args;
 use graphql_client::{GraphQLQuery, Response};
 
-use crate::api::ApiClient;
+use crate::{api::Client, credential::Credentials};
 
 use self::describe_deployment::{
     DeploymentService,
@@ -47,8 +47,10 @@ impl DescribeArgs {
             service,
         });
 
-        let client = ApiClient::new();
-        let res: Response<ResponseData> = client.post(&request_body).await?;
+        let user = Credentials::load()?;
+        let client = Client::new_with_token(user.access_token);
+
+        let res: Response<ResponseData> = client.query(&request_body).await?;
         if let Some(errors) = res.errors.clone() {
             for err in errors {
                 println!("Error: {}", err.message);

--- a/src/command/deployments/fork.rs
+++ b/src/command/deployments/fork.rs
@@ -7,10 +7,11 @@ use starknet::providers::{jsonrpc::HttpTransport, JsonRpcClient, Provider};
 use url::Url;
 
 use crate::{
-    api::ApiClient,
+    api::Client,
     command::deployments::fork::fork_deployment::{
         DeploymentTier, ForkDeploymentForkDeployment::KatanaConfig, Variables,
     },
+    credential::Credentials,
 };
 
 use super::{services::ForkServiceCommands, Long, Tier};
@@ -53,8 +54,10 @@ impl ForkArgs {
             wait: Some(true),
         });
 
-        let client = ApiClient::new();
-        let res: Response<fork_deployment::ResponseData> = client.post(&request_body).await?;
+        let user = Credentials::load()?;
+        let client = Client::new_with_token(user.access_token);
+
+        let res: Response<fork_deployment::ResponseData> = client.query(&request_body).await?;
         if let Some(errors) = res.errors.clone() {
             for err in errors {
                 println!("Error: {}", err.message);

--- a/src/command/deployments/list.rs
+++ b/src/command/deployments/list.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use clap::Args;
 use graphql_client::{GraphQLQuery, Response};
 
-use crate::api::ApiClient;
+use crate::{api::Client, credential::Credentials};
 
 use self::list_deployments::{ResponseData, Variables};
 
@@ -24,8 +24,10 @@ impl ListArgs {
     pub async fn run(&self) -> Result<()> {
         let request_body = ListDeployments::build_query(Variables {});
 
-        let client = ApiClient::new();
-        let res: Response<ResponseData> = client.post(&request_body).await?;
+        let user = Credentials::load()?;
+        let client = Client::new_with_token(user.access_token);
+
+        let res: Response<ResponseData> = client.query(&request_body).await?;
         if let Some(errors) = res.errors.clone() {
             for err in errors {
                 println!("Error: {}", err.message);

--- a/src/command/deployments/update.rs
+++ b/src/command/deployments/update.rs
@@ -6,12 +6,13 @@ use graphql_client::{GraphQLQuery, Response};
 
 use self::update_deployment::UpdateServiceInput;
 use crate::{
-    api::ApiClient,
+    api::Client,
     command::deployments::update::update_deployment::{
         DeploymentService, DeploymentTier,
         UpdateDeploymentUpdateDeployment::{KatanaConfig, MadaraConfig, ToriiConfig},
         UpdateKatanaConfigInput, UpdateServiceConfigInput, Variables,
     },
+    credential::Credentials,
 };
 
 use super::services::UpdateServiceCommands;
@@ -79,8 +80,10 @@ impl UpdateArgs {
             wait: Some(true),
         });
 
-        let client = ApiClient::new();
-        let res: Response<update_deployment::ResponseData> = client.post(&request_body).await?;
+        let user = Credentials::load()?;
+        let client = Client::new_with_token(user.access_token);
+
+        let res: Response<update_deployment::ResponseData> = client.query(&request_body).await?;
         if let Some(errors) = res.errors.clone() {
             for err in errors {
                 println!("Error: {}", err.message);

--- a/src/command/teams/members.rs
+++ b/src/command/teams/members.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use clap::Args;
 use graphql_client::{GraphQLQuery, Response};
 
-use crate::api::ApiClient;
+use crate::{api::Client, credential::Credentials};
 
 #[derive(GraphQLQuery)]
 #[graphql(
@@ -21,8 +21,10 @@ impl TeamListArgs {
         let request_body =
             TeamMembersList::build_query(self::team_members_list::Variables { team: team.clone() });
 
-        let client = ApiClient::new();
-        let res: Response<team_members_list::ResponseData> = client.post(&request_body).await?;
+        let user = Credentials::load()?;
+        let client = Client::new_with_token(user.access_token);
+
+        let res: Response<team_members_list::ResponseData> = client.query(&request_body).await?;
         if let Some(errors) = res.errors.clone() {
             for err in errors {
                 println!("Error: {}", err.message);
@@ -70,8 +72,10 @@ impl TeamAddArgs {
             accounts: self.account.clone(),
         });
 
-        let client = ApiClient::new();
-        let res: Response<team_member_add::ResponseData> = client.post(&request_body).await?;
+        let user = Credentials::load()?;
+        let client = Client::new_with_token(user.access_token);
+
+        let res: Response<team_member_add::ResponseData> = client.query(&request_body).await?;
         if let Some(errors) = res.errors {
             for err in errors {
                 println!("Error: {}", err.message);
@@ -106,8 +110,10 @@ impl TeamRemoveArgs {
             accounts: self.account.clone(),
         });
 
-        let client = ApiClient::new();
-        let res: Response<team_member_remove::ResponseData> = client.post(&request_body).await?;
+        let user = Credentials::load()?;
+        let client = Client::new_with_token(user.access_token);
+
+        let res: Response<team_member_remove::ResponseData> = client.query(&request_body).await?;
         if let Some(errors) = res.errors {
             for err in errors {
                 println!("Error: {}", err.message);

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -37,9 +37,9 @@ impl Credentials {
     }
 
     pub fn write(&self) -> io::Result<()> {
-        // create the path if it doesn't yet exist
+        // create the dir if it doesn't yet exist
         let path = get_file_path();
-        fs::create_dir_all(&path)?;
+        fs::create_dir_all(&path.parent().expect("qed; parent exist"))?;
 
         let content = serde_json::to_string_pretty(&self)?;
         fs::write(path, content)?;

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::fs;
 use std::io::{self};
 use std::path::PathBuf;
 
@@ -30,15 +31,18 @@ impl Credentials {
 
     pub fn load() -> io::Result<Self> {
         let path = get_file_path();
-        let content = std::fs::read_to_string(path)?;
+        let content = fs::read_to_string(path)?;
         let credentials = serde_json::from_str(&content)?;
         Ok(credentials)
     }
 
     pub fn write(&self) -> io::Result<()> {
+        // create the path if it doesn't yet exist
         let path = get_file_path();
+        fs::create_dir_all(&path)?;
+
         let content = serde_json::to_string_pretty(&self)?;
-        std::fs::write(path, content)?;
+        fs::write(path, content)?;
         Ok(())
     }
 }

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -37,7 +37,7 @@ impl Credentials {
     }
 
     pub fn write(&self) -> io::Result<()> {
-        // create the dir if it doesn't yet exist
+        // create the dir paths if it doesn't yet exist
         let path = get_file_path();
         fs::create_dir_all(&path.parent().expect("qed; parent exist"))?;
 

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -39,7 +39,7 @@ impl Credentials {
     pub fn write(&self) -> io::Result<()> {
         // create the dir paths if it doesn't yet exist
         let path = get_file_path();
-        fs::create_dir_all(&path.parent().expect("qed; parent exist"))?;
+        fs::create_dir_all(path.parent().expect("qed; parent exist"))?;
 
         let content = serde_json::to_string_pretty(&self)?;
         fs::write(path, content)?;


### PR DESCRIPTION
- save account info in `credentials.json`
- refactor the `ApiClient` to expose associated methods for each api path
- request the account info on auth callback 