### PR TITLE
Add support for Common tier in deployment commands

### DIFF
--- a/cli/src/command/deployments/create.rs
+++ b/cli/src/command/deployments/create.rs
@@ -96,6 +96,7 @@ impl CreateArgs {
 
         let tier = match &self.tier {
             Tier::Basic => DeploymentTier::basic,
+            Tier::Common => DeploymentTier::common,
             Tier::Rare => DeploymentTier::rare,
             Tier::Epic => DeploymentTier::epic,
         };

--- a/cli/src/command/deployments/fork.rs
+++ b/cli/src/command/deployments/fork.rs
@@ -31,6 +31,7 @@ impl ForkArgs {
 
         let tier = match &self.tier {
             Tier::Basic => DeploymentTier::basic,
+            Tier::Common => DeploymentTier::common,
             Tier::Rare => DeploymentTier::rare,
             Tier::Epic => DeploymentTier::epic,
         };

--- a/cli/src/command/deployments/mod.rs
+++ b/cli/src/command/deployments/mod.rs
@@ -54,6 +54,7 @@ impl Deployments {
 #[derive(clap::ValueEnum, Clone, Debug, serde::Serialize)]
 pub enum Tier {
     Basic,
+    Common,
     Rare,
     Epic,
 }

--- a/cli/src/command/deployments/update.rs
+++ b/cli/src/command/deployments/update.rs
@@ -54,6 +54,7 @@ impl UpdateArgs {
 
         let tier = match &self.tier {
             Tier::Basic => DeploymentTier::basic,
+            Tier::Common => DeploymentTier::common,
             Tier::Rare => DeploymentTier::rare,
             Tier::Epic => DeploymentTier::epic,
         };


### PR DESCRIPTION
Introduced the 'Common' tier option in the deployment commands for create, update, and fork. This change expands the tier selection, aligning it with the new requirements. Updated related enums and match statements accordingly to integrate the new tier.