### PR TITLE
Add support for Saya deployments

### DIFF
--- a/cli/src/command/deployments/create.rs
+++ b/cli/src/command/deployments/create.rs
@@ -5,7 +5,7 @@ use clap::Args;
 use slot::api::Client;
 use slot::credential::Credentials;
 use slot::graphql::deployments::create_deployment::CreateDeploymentCreateDeployment::{
-    KatanaConfig, MadaraConfig, ToriiConfig,
+    KatanaConfig, MadaraConfig, SayaConfig, ToriiConfig,
 };
 use slot::graphql::deployments::create_deployment::*;
 use slot::graphql::deployments::CreateDeployment;
@@ -58,6 +58,7 @@ impl CreateArgs {
                     }),
                     torii: None,
                     madara: None,
+                    saya: None,
                 }),
             },
             CreateServiceCommands::Torii(config) => CreateServiceInput {
@@ -73,6 +74,7 @@ impl CreateArgs {
                         index_pending: config.index_pending,
                         polling_interval: config.polling_interval,
                     }),
+                    saya: None,
                 }),
             },
             CreateServiceCommands::Madara(config) => CreateServiceInput {
@@ -89,6 +91,31 @@ impl CreateArgs {
                         validator: config.validator.then_some(true),
                         sealing: config.sealing.clone().map(|s| s.to_string()),
                         chain: config.chain.clone().map(|c| c.to_string()),
+                    }),
+                    saya: None,
+                }),
+            },
+            CreateServiceCommands::Saya(config) => CreateServiceInput {
+                type_: DeploymentService::saya,
+                version: config.version.clone(),
+                config: Some(CreateServiceConfigInput {
+                    katana: None,
+                    torii: None,
+                    madara: None,
+                    saya: Some(CreateSayaConfigInput {
+                        mode: config.mode.clone(),
+                        rpc_url: config.rpc_url.clone(),
+                        registry: config.registry.clone(),
+                        settlement_contract: config.settlement_contract.clone(),
+                        world: config.world.clone().to_string(),
+                        prover_url: config.prover_url.clone(),
+                        store_proofs: config.store_proofs.unwrap_or(false),
+                        starknet_url: config.starknet_url.clone(),
+                        signer_key: config.signer_key.clone(),
+                        signer_address: config.signer_address.clone(),
+                        private_key: config.private_key.clone(),
+                        batch_size: config.batch_size.unwrap_or(1),
+                        start_block: config.start_block.unwrap_or(0),
                     }),
                 }),
             },
@@ -124,6 +151,10 @@ impl CreateArgs {
         if let Some(data) = res.data {
             println!("Deployment success 🚀");
             match data.create_deployment {
+                SayaConfig(config) => {
+                    println!("\nConfiguration:");
+                    println!("  RPC URL: {}", config.rpc_url);
+                }
                 ToriiConfig(config) => {
                     println!("\nConfiguration:");
                     println!("  World: {}", config.world);
@@ -149,6 +180,7 @@ impl CreateArgs {
             CreateServiceCommands::Katana(_) => "katana",
             CreateServiceCommands::Torii(_) => "torii",
             CreateServiceCommands::Madara(_) => "madara",
+            CreateServiceCommands::Saya(_) => "saya",
         };
 
         println!(

--- a/cli/src/command/deployments/delete.rs
+++ b/cli/src/command/deployments/delete.rs
@@ -11,6 +11,7 @@ pub enum Service {
     Katana,
     Torii,
     Madara,
+    Saya,
 }
 
 #[derive(Debug, Args)]
@@ -49,6 +50,7 @@ impl DeleteArgs {
             Service::Katana => DeploymentService::katana,
             Service::Torii => DeploymentService::torii,
             Service::Madara => DeploymentService::madara,
+            Service::Saya => DeploymentService::saya,
         };
 
         let request_body = DeleteDeployment::build_query(Variables {

--- a/cli/src/command/deployments/describe.rs
+++ b/cli/src/command/deployments/describe.rs
@@ -4,7 +4,7 @@ use super::services::Service;
 use anyhow::Result;
 use clap::Args;
 use slot::graphql::deployments::describe_deployment::DescribeDeploymentDeploymentConfig::{
-    KatanaConfig, MadaraConfig, ToriiConfig,
+    KatanaConfig, MadaraConfig, SayaConfig, ToriiConfig,
 };
 use slot::graphql::deployments::{describe_deployment::*, DescribeDeployment};
 use slot::graphql::{GraphQLQuery, Response};
@@ -26,6 +26,7 @@ impl DescribeArgs {
             Service::Torii => DeploymentService::torii,
             Service::Katana => DeploymentService::katana,
             Service::Madara => DeploymentService::madara,
+            Service::Saya => DeploymentService::saya,
         };
 
         let request_body = DescribeDeployment::build_query(Variables {
@@ -76,6 +77,10 @@ impl DescribeArgs {
                         println!("\nEndpoints:");
                         println!("  Version: {}", config.version);
                         println!("  RPC: {}", config.rpc);
+                    }
+                    SayaConfig(config) => {
+                        println!("\nEndpoints:");
+                        println!("  RPC URL: {}", config.rpc_url);
                     }
                 }
             }

--- a/cli/src/command/deployments/logs.rs
+++ b/cli/src/command/deployments/logs.rs
@@ -80,6 +80,7 @@ impl LogReader {
             Service::Katana => DeploymentService::katana,
             Service::Torii => DeploymentService::torii,
             Service::Madara => DeploymentService::madara,
+            Service::Saya => DeploymentService::saya,
         };
 
         let request_body = DeploymentLogs::build_query(Variables {

--- a/cli/src/command/deployments/services/mod.rs
+++ b/cli/src/command/deployments/services/mod.rs
@@ -3,11 +3,13 @@ use clap::{Subcommand, ValueEnum};
 use self::{
     katana::{KatanaAccountArgs, KatanaCreateArgs, KatanaForkArgs, KatanaUpdateArgs},
     madara::MadaraCreateArgs,
+    saya::{SayaCreateArgs, SayaUpdateArgs},
     torii::{ToriiCreateArgs, ToriiUpdateArgs},
 };
 
 mod katana;
 mod madara;
+mod saya;
 mod torii;
 
 #[derive(Debug, Subcommand, serde::Serialize)]
@@ -19,6 +21,8 @@ pub enum CreateServiceCommands {
     Torii(ToriiCreateArgs),
     #[command(about = "Madara deployment.")]
     Madara(MadaraCreateArgs),
+    #[command(about = "Saya deployment.")]
+    Saya(SayaCreateArgs),
 }
 
 #[derive(Debug, Subcommand, serde::Serialize)]
@@ -28,6 +32,8 @@ pub enum UpdateServiceCommands {
     Katana(KatanaUpdateArgs),
     #[command(about = "Torii deployment.")]
     Torii(ToriiUpdateArgs),
+    #[command(about = "Saya deployment.")]
+    Saya(SayaUpdateArgs),
 }
 
 #[derive(Debug, Subcommand, serde::Serialize)]
@@ -51,4 +57,5 @@ pub enum Service {
     Katana,
     Torii,
     Madara,
+    Saya,
 }

--- a/cli/src/command/deployments/services/saya.rs
+++ b/cli/src/command/deployments/services/saya.rs
@@ -1,0 +1,83 @@
+use clap::Args;
+use starknet::core::types::Felt;
+
+#[derive(Clone, Debug, Args, serde::Serialize)]
+#[command(next_help_heading = "Saya create options")]
+pub struct SayaCreateArgs {
+    #[arg(long, short, value_name = "version")]
+    #[arg(help = "Service version to use.")]
+    pub version: Option<String>,
+
+    #[arg(long)]
+    #[arg(value_name = "mode")]
+    #[arg(help = "The mode to use for the deployment.")]
+    pub mode: String,
+
+    #[arg(long)]
+    #[arg(value_name = "rpc_url")]
+    #[arg(help = "The Katana RPC endpoint.")]
+    pub rpc_url: String,
+
+    #[arg(long)]
+    #[arg(value_name = "registry")]
+    #[arg(help = "Registry address.")]
+    pub registry: String,
+
+    #[arg(long)]
+    #[arg(value_name = "settlement_contract")]
+    #[arg(help = "Settlement contract address.")]
+    pub settlement_contract: String,
+
+    #[arg(long)]
+    #[arg(value_name = "world")]
+    #[arg(help = "World address.")]
+    pub world: Felt,
+
+    #[arg(long)]
+    #[arg(value_name = "start_block")]
+    #[arg(help = "Specify a block to start indexing from.")]
+    pub start_block: Option<i64>,
+
+    #[arg(long)]
+    #[arg(value_name = "prover_url")]
+    #[arg(help = "Prover URL.")]
+    pub prover_url: String,
+
+    #[arg(long)]
+    #[arg(value_name = "prover_key")]
+    #[arg(help = "Store proofs.")]
+    pub store_proofs: Option<bool>,
+
+    #[arg(long)]
+    #[arg(value_name = "starknet_url")]
+    #[arg(help = "Starknet URL.")]
+    pub starknet_url: String,
+
+    #[arg(long)]
+    #[arg(value_name = "signer_key")]
+    #[arg(help = "Signer key.")]
+    pub signer_key: String,
+
+    #[arg(long)]
+    #[arg(value_name = "signer_address")]
+    #[arg(help = "Signer address.")]
+    pub signer_address: String,
+
+    #[arg(long)]
+    #[arg(value_name = "private_key")]
+    #[arg(help = "Private key.")]
+    pub private_key: String,
+
+    #[arg(long)]
+    #[arg(value_name = "batch_size")]
+    #[arg(help = "Batch size.")]
+    pub batch_size: Option<i64>,
+}
+
+#[derive(Clone, Debug, Args, serde::Serialize)]
+#[command(next_help_heading = "Saya update options")]
+pub struct SayaUpdateArgs {
+    #[arg(long, short, value_name = "version")]
+    #[arg(help = "Service version to use.")]
+    pub version: Option<String>,
+}

--- a/cli/src/command/deployments/update.rs
+++ b/cli/src/command/deployments/update.rs
@@ -7,7 +7,7 @@ use clap::Args;
 use slot::api::Client;
 use slot::credential::Credentials;
 use slot::graphql::deployments::update_deployment::UpdateDeploymentUpdateDeployment::{
-    KatanaConfig, MadaraConfig, ToriiConfig,
+    KatanaConfig, MadaraConfig, SayaConfig, ToriiConfig,
 };
 use slot::graphql::deployments::update_deployment::{
     self, UpdateKatanaConfigInput, UpdateServiceConfigInput, UpdateServiceInput,
@@ -47,6 +47,11 @@ impl UpdateArgs {
             },
             UpdateServiceCommands::Torii(config) => UpdateServiceInput {
                 type_: DeploymentService::torii,
+                version: config.version.clone(),
+                config: Some(UpdateServiceConfigInput { katana: None }),
+            },
+            UpdateServiceCommands::Saya(config) => UpdateServiceInput {
+                type_: DeploymentService::saya,
                 version: config.version.clone(),
                 config: Some(UpdateServiceConfigInput { katana: None }),
             },
@@ -96,12 +101,17 @@ impl UpdateArgs {
                     println!("  RPC: {}", config.rpc);
                 }
                 MadaraConfig => {} // TODO: implement
+                SayaConfig(config) => {
+                    println!("\nConfiguration:");
+                    println!("  RPC URL: {}", config.rpc_url);
+                }
             }
         }
 
         let service = match &self.update_commands {
             UpdateServiceCommands::Katana(_) => "katana",
             UpdateServiceCommands::Torii(_) => "torii",
+            UpdateServiceCommands::Saya(_) => "saya",
         };
 
         println!(

--- a/slot/schema.json
+++ b/slot/schema.json
@@ -11830,6 +11830,199 @@
             {
               "defaultValue": null,
               "description": null,
+              "name": "mode",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "rpcUrl",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "registry",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "settlementContract",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "world",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "proverUrl",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "storeProofs",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "starknetUrl",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "signerKey",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "signerAddress",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "privateKey",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "batchSize",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "startBlock",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "interfaces": [],
+          "kind": "INPUT_OBJECT",
+          "name": "CreateSayaConfigInput",
+          "possibleTypes": []
+        },
+        {
+          "description": null,
+          "enumValues": [],
+          "fields": [],
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": null,
               "name": "katana",
               "type": {
                 "kind": "INPUT_OBJECT",
@@ -11854,6 +12047,16 @@
               "type": {
                 "kind": "INPUT_OBJECT",
                 "name": "CreateMadaraConfigInput",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "saya",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "CreateSayaConfigInput",
                 "ofType": null
               }
             }
@@ -12463,6 +12666,11 @@
             {
               "kind": "OBJECT",
               "name": "MadaraConfig",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "SayaConfig",
               "ofType": null
             }
           ]
@@ -13350,6 +13558,12 @@
               "description": null,
               "isDeprecated": false,
               "name": "madara"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "saya"
             }
           ],
           "fields": [],
@@ -20653,69 +20867,6 @@
                     "name": null,
                     "ofType": {
                       "kind": "SCALAR",
-                      "name": "ID",
-                      "ofType": null
-                    }
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "chainId",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "ChainID",
-                      "ofType": null
-                    }
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "starterpackIds",
-                  "type": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "NON_NULL",
-                      "name": null,
-                      "ofType": {
-                        "kind": "SCALAR",
-                        "name": "ID",
-                        "ofType": null
-                      }
-                    }
-                  }
-                }
-              ],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "deployAccount",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "id",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
                       "name": "String",
                       "ofType": null
                     }
@@ -20763,37 +20914,6 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "token",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  }
-                }
-              ],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "discordRevoke",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
                   "ofType": null
                 }
               }
@@ -27820,6 +27940,241 @@
           "interfaces": [],
           "kind": "ENUM",
           "name": "Role",
+          "possibleTypes": []
+        },
+        {
+          "description": null,
+          "enumValues": [],
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "version",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "mode",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "rpcUrl",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "registry",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "settlementContract",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "world",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "proverUrl",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "storeProofs",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "starknetUrl",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "signerKey",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "signerAddress",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "privateKey",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "batchSize",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "startBlock",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "SayaConfig",
           "possibleTypes": []
         },
         {

--- a/slot/src/graphql/deployments/create.graphql
+++ b/slot/src/graphql/deployments/create.graphql
@@ -13,9 +13,11 @@ mutation CreateDeployment(
 		regions: $regions
 	) {
 		__typename
+
 		... on KatanaConfig {
 			rpc
 		}
+
 		... on ToriiConfig {
 			graphql
 			grpc
@@ -24,9 +26,14 @@ mutation CreateDeployment(
 			startBlock
 			indexPending
 		}
+
 		... on MadaraConfig {
 			rpc
 			name
+		}
+
+		... on SayaConfig {
+			rpcUrl
 		}
 	}
 }

--- a/slot/src/graphql/deployments/describe.graphql
+++ b/slot/src/graphql/deployments/describe.graphql
@@ -5,10 +5,12 @@ query DescribeDeployment($project: String!, $service: DeploymentService!) {
     tier
     config {
       __typename
+
       ... on KatanaConfig {
         version
         rpc
       }
+
       ... on ToriiConfig {
         version
         graphql
@@ -22,6 +24,10 @@ query DescribeDeployment($project: String!, $service: DeploymentService!) {
         version
         rpc
         name
+      }
+
+      ... on SayaConfig {
+        rpcUrl
       }
     }
   }

--- a/slot/src/graphql/deployments/update.graphql
+++ b/slot/src/graphql/deployments/update.graphql
@@ -11,9 +11,11 @@ mutation UpdateDeployment(
     wait: $wait
   ) {
     __typename
+
     ... on KatanaConfig {
       rpc
     }
+
     ... on ToriiConfig {
       graphql
       grpc
@@ -22,6 +24,9 @@ mutation UpdateDeployment(
       startBlock
       indexPending
     }
-    # TODO: handle update
+
+    ... on SayaConfig {
+      rpcUrl
+    }
   }
 }


### PR DESCRIPTION
Integrated Saya deployment commands and configuration across CLI, GraphQL, and schema files. This allows users to create, update, delete, and describe Saya deployments, with detailed configurations and options specific to the Saya service.