### PR TITLE
feat: add dev mode support for Katana

### DIFF
--- a/cli/src/command/deployments/create.rs
+++ b/cli/src/command/deployments/create.rs
@@ -55,6 +55,7 @@ impl CreateArgs {
                         invoke_max_steps: config.invoke_max_steps,
                         validate_max_steps: config.validate_max_steps,
                         genesis: config.genesis.clone(),
+                        dev_mode: config.dev_mode,
                     }),
                     torii: None,
                     madara: None,

--- a/cli/src/command/deployments/services/katana.rs
+++ b/cli/src/command/deployments/services/katana.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use clap::Args;
+use clap::{ArgAction, Args};
 use katana_primitives::genesis;
 use katana_primitives::genesis::json::GenesisJson;
 
@@ -51,6 +51,10 @@ pub struct KatanaCreateArgs {
     #[arg(help = "Path to a Katana genesis file.")]
     #[arg(value_parser = genesis_value_parser)]
     pub genesis: Option<String>,
+
+    #[arg(long, action = ArgAction::Set, default_value_t = false)]
+    #[arg(help = "Enable Katana dev mode for specific endpoints.")]
+    pub dev_mode: bool,
 }
 
 #[derive(Debug, Args, serde::Serialize)]
@@ -87,6 +91,10 @@ pub struct KatanaUpdateArgs {
     #[arg(long, value_name = "gas_price")]
     #[arg(help = "Gas Price.")]
     pub gas_price: Option<u64>,
+
+    #[arg(long, action = ArgAction::Set, default_value_t = false)]
+    #[arg(help = "Enable Katana dev mode for specific endpoints.")]
+    pub dev_mode: bool,
 }
 
 #[derive(Debug, Args, serde::Serialize)]

--- a/slot/schema.json
+++ b/slot/schema.json
@@ -11734,6 +11734,20 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "devMode",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
             }
           ],
           "interfaces": [],
@@ -20141,6 +20155,20 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "devMode",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
                   "ofType": null
                 }
               }


### PR DESCRIPTION
Katana now requires to be explicitly started with `--dev` in order to expose some dev endpoints like `dev_predeployedAccounts`.

This PR aims at adding the support for this option on infra side.
