### PR TITLE
Update to new `account_sdk` session creation logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4246,6 +4246,7 @@ dependencies = [
  "account_sdk",
  "anyhow",
  "axum",
+ "base64 0.22.1",
  "dirs",
  "graphql_client",
  "hyper 1.4.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "account_sdk"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/controller?rev=0b5c318#0b5c318f233c6a1af4f4e781c060c46dab97334e"
+source = "git+https://github.com/cartridge-gg/controller?rev=e433a45#e433a4551506d3d92075234135a90fe98b82b654"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2663,9 +2663,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -5448,19 +5448,20 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
@@ -5485,9 +5486,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5495,9 +5496,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5508,9 +5509,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasm-bindgen-test"
@@ -5539,9 +5540,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/cli/src/command/auth/session.rs
+++ b/cli/src/command/auth/session.rs
@@ -2,10 +2,8 @@ use std::str::FromStr;
 
 use anyhow::{anyhow, ensure, Result};
 use clap::Parser;
-use slot::session::{self, Policy};
+use slot::session::{self, PolicyMethod};
 use starknet::core::types::Felt;
-use starknet::providers::{jsonrpc::HttpTransport, JsonRpcClient, Provider};
-use starknet::signers::{LocalWallet, Signer, SigningKey};
 use url::Url;
 
 #[derive(Debug, Parser)]
@@ -17,39 +15,28 @@ pub struct CreateSession {
     rpc_url: String,
 
     #[arg(help = "The session's policies.")]
-    #[arg(value_parser = parse_policy)]
+    #[arg(value_parser = parse_policy_method)]
     #[arg(required = true)]
-    policies: Vec<Policy>,
+    policies: Vec<PolicyMethod>,
 }
 
 impl CreateSession {
     pub async fn run(&self) -> Result<()> {
         let url = Url::parse(&self.rpc_url)?;
-        let chain_id = get_network_chain_id(url.clone()).await?;
-
-        let wallet = LocalWallet::from(SigningKey::from_random());
-        let pubkey = wallet.get_public_key().await?;
-
-        let session = session::create(pubkey.scalar(), url, &self.policies).await?;
-        session::store(chain_id, &session)?;
-
+        let session = session::create(url, &self.policies).await?;
+        session::store(session.chain_id, &session)?;
         Ok(())
     }
 }
 
-fn parse_policy(value: &str) -> Result<Policy> {
+fn parse_policy_method(value: &str) -> Result<PolicyMethod> {
     let mut parts = value.split(',');
 
     let target = parts.next().ok_or(anyhow!("missing target"))?.to_owned();
     let target = Felt::from_str(&target)?;
     let method = parts.next().ok_or(anyhow!("missing method"))?.to_owned();
 
-    ensure!(parts.next().is_none(), " bruh");
+    ensure!(parts.next().is_none());
 
-    Ok(Policy { target, method })
-}
-
-async fn get_network_chain_id(url: Url) -> Result<Felt> {
-    let provider = JsonRpcClient::new(HttpTransport::new(url));
-    Ok(provider.chain_id().await?)
+    Ok(PolicyMethod { target, method })
 }

--- a/slot/Cargo.toml
+++ b/slot/Cargo.toml
@@ -29,4 +29,4 @@ hyper.workspace = true
 serde_with = "3.9.0"
 
 # Must be synced across Dojo
-account_sdk = { git = "https://github.com/cartridge-gg/controller", rev = "0b5c318" }
+account_sdk = { git = "https://github.com/cartridge-gg/controller", rev = "e433a45" }

--- a/slot/Cargo.toml
+++ b/slot/Cargo.toml
@@ -30,3 +30,4 @@ serde_with = "3.9.0"
 
 # Must be synced across Dojo
 account_sdk = { git = "https://github.com/cartridge-gg/controller", rev = "e433a45" }
+base64 = "0.22.1"

--- a/slot/src/error.rs
+++ b/slot/src/error.rs
@@ -1,3 +1,6 @@
+use account_sdk::signers::SignError;
+use starknet::core::utils::NonAsciiNameError;
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error(transparent)]
@@ -20,4 +23,10 @@ pub enum Error {
 
     #[error(transparent)]
     Anyhow(#[from] anyhow::Error),
+
+    #[error("Invalid method name: {0}")]
+    InvalidMethodName(NonAsciiNameError),
+
+    #[error(transparent)]
+    Signing(#[from] SignError),
 }

--- a/slot/src/lib.rs
+++ b/slot/src/lib.rs
@@ -12,4 +12,5 @@ pub mod vars;
 pub(crate) mod error;
 pub(crate) mod utils;
 
+pub use account_sdk;
 pub use error::Error;

--- a/slot/src/session.rs
+++ b/slot/src/session.rs
@@ -545,6 +545,6 @@ mod tests {
                 "0x4e968edd81ba46224f7623f4095d754dc80f6cbd55583cde0ed2a143aeb7321"
             ))
         );
-        assert_eq!(response.already_registered, false);
+        assert!(!response.already_registered);
     }
 }

--- a/slot/src/session.rs
+++ b/slot/src/session.rs
@@ -523,8 +523,6 @@ mod tests {
         assert_eq!(response, actual)
     }
 
-    // Must follow how the server serialize the response object:
-    // https://github.com/cartridge-gg/controller/blob/90b767bcc6478f0e02973f7237bc2a974f745adf/packages/keychain/src/pages/session.tsx#L58-L60
     #[test]
     fn deserialize_backend_encoded_response() {
         let encoded_response = "eyJ1c2VybmFtZSI6ImpvaG5zbWl0aCIsImFkZHJlc3MiOiIweDM5NzMzM2U5OTNhZTE2MmI0NzY2OTBlMTQwMTU0OGFlOTdhODgxOTk1NTUwNmI4YmM5MThlMDY3YmRhZmMzIiwib3duZXJHdWlkIjoiMHg1ZDc3MDliMGE0ODVlNjRhNTQ5YWRhOWJkMTRkMzA0MTkzNjQxMjdkZmQzNTFlMDFmMzg4NzFjODI1MDBjZDciLCJ0cmFuc2FjdGlvbkhhc2giOiIweDRlOTY4ZWRkODFiYTQ2MjI0Zjc2MjNmNDA5NWQ3NTRkYzgwZjZjYmQ1NTU4M2NkZTBlZDJhMTQzYWViNzMyMSJ9";

--- a/slot/src/session.rs
+++ b/slot/src/session.rs
@@ -198,6 +198,8 @@ fn store_at(
 }
 
 /// The response object to the session creation request.
+//
+// A reflection of https://github.com/cartridge-gg/controller/blob/90b767bcc6478f0e02973f7237bc2a974f745adf/packages/keychain/src/pages/session.tsx#L15-L21
 #[cfg_attr(test, derive(PartialEq, Serialize))]
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -220,6 +222,8 @@ pub struct SessionCreationResponse {
 }
 
 impl SessionCreationResponse {
+    // Following how the server serialize the response object:
+    // https://github.com/cartridge-gg/controller/blob/90b767bcc6478f0e02973f7237bc2a974f745adf/packages/keychain/src/pages/session.tsx#L58-L60
     pub fn from_encoded(encoded: &str) -> anyhow::Result<Self> {
         use base64::{engine::general_purpose, Engine as _};
 

--- a/slot/src/session.rs
+++ b/slot/src/session.rs
@@ -228,7 +228,7 @@ impl SessionCreationResponse {
         use base64::{engine::general_purpose, Engine as _};
 
         // Decode the Base64 string
-        let bytes = general_purpose::STANDARD.decode(encoded)?;
+        let bytes = general_purpose::STANDARD_NO_PAD.decode(encoded)?;
         let decoded = String::from_utf8(bytes)?;
 
         Ok(serde_json::from_str(&decoded)?)


### PR DESCRIPTION
ref: https://github.com/dojoengine/dojo/pull/2303

- bump `account_sdk` rev
- re-export `account_sdk` so that Dojo don't have to manually sync the `account_sdk` version
- update the session creation logic