### PR TITLE
Change draft release to regular release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
           path: ${{ steps.artifacts.outputs.file_name }}
           retention-days: 1
 
-  create-draft-release:
+  create-release:
     runs-on: ubuntu-latest
     needs: [prepare, release]
     env:
@@ -133,4 +133,4 @@ jobs:
           echo "version=$(cargo get workspace.package.version)" >> $GITHUB_OUTPUT
       - name: Display structure of downloaded files
         run: ls -R artifacts
-      - run: gh release create v${{ steps.version_info.outputs.version }} ./artifacts/*.gz --generate-notes --draft
+      - run: gh release create v${{ steps.version_info.outputs.version }} ./artifacts/*.gz --generate-notes


### PR DESCRIPTION
Updated the GitHub Actions workflow to create regular releases instead of draft releases. This modification ensures that the releases are immediately available upon execution, streamlining the release process.