### PR TITLE
Remove delete.sh script

### DIFF
--- a/delete.sh
+++ b/delete.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-for n in {1..100}; do
-    cargo run -- deployments delete "ls-tmp-$n" torii -f
-    cargo run -- deployments delete "ls-tmp-$n" katana -f
-    cargo run -- deployments delete "ls-tmp-$n" saya -f
-done


### PR DESCRIPTION
The delete.sh script was responsible for deleting specific deployments sequentially. Given recent changes in deployment practices, this script is now obsolete and no longer necessary in the repository.