### PR TITLE
fix: add back the account address field in credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4283,6 +4283,7 @@ version = "0.18.0"
 dependencies = [
  "account_sdk",
  "anyhow",
+ "assert_matches",
  "axum",
  "base64 0.22.1",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4291,7 +4291,6 @@ dependencies = [
  "reqwest 0.12.7",
  "serde",
  "serde_json",
- "serde_with 3.9.0",
  "starknet 0.12.0",
  "tempfile",
  "thiserror",

--- a/cli/src/command/auth/login.rs
+++ b/cli/src/command/auth/login.rs
@@ -13,13 +13,13 @@ use hyper::StatusCode;
 use log::error;
 use serde::Deserialize;
 use slot::{
-    account::Account,
+    account::AccountInfo,
     api::Client,
     browser,
     credential::Credentials,
     graphql::auth::{
         me::{ResponseData, Variables},
-        AccountTryFromGraphQLError, Me,
+        Me,
     },
     server::LocalServer,
     vars,
@@ -85,9 +85,6 @@ enum CallbackError {
 
     #[error(transparent)]
     Slot(#[from] slot::Error),
-
-    #[error(transparent)]
-    Parse(#[from] AccountTryFromGraphQLError),
 }
 
 impl IntoResponse for CallbackError {
@@ -118,7 +115,7 @@ async fn handler(
             let data: ResponseData = api.query(&request_body).await?;
 
             let account = data.me.expect("missing payload");
-            let account = Account::try_from(account)?;
+            let account = AccountInfo::from(account);
 
             // 3. Store the access token locally
             Credentials::new(account, token).store()?;

--- a/slot/Cargo.toml
+++ b/slot/Cargo.toml
@@ -26,7 +26,6 @@ starknet.workspace = true
 url.workspace = true
 tempfile = "3.10.1"
 hyper.workspace = true
-serde_with = "3.9.0"
 
 account_sdk = { git = "https://github.com/cartridge-gg/controller", rev = "61d2fd0" }
 base64 = "0.22.1"

--- a/slot/Cargo.toml
+++ b/slot/Cargo.toml
@@ -29,3 +29,6 @@ hyper.workspace = true
 
 account_sdk = { git = "https://github.com/cartridge-gg/controller", rev = "61d2fd0" }
 base64 = "0.22.1"
+
+[dev-dependencies]
+assert_matches = "1.5.0"

--- a/slot/src/account.rs
+++ b/slot/src/account.rs
@@ -23,7 +23,7 @@ pub struct Controller {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SignerType {
-    Webauthn,
+    WebAuthn,
     StarknetAccount,
     Other(String),
 }

--- a/slot/src/account.rs
+++ b/slot/src/account.rs
@@ -1,22 +1,35 @@
+use crate::graphql::auth::me::MeMeCredentialsWebauthn as WebAuthnCredential;
 use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
+use starknet::core::types::Felt;
 
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub struct Account {
+/// Controller account information.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(test, derive(Default))]
+pub struct AccountInfo {
+    /// The username of the account.
     pub id: String,
     pub name: Option<String>,
-    pub credentials: AccountCredentials,
+    pub controllers: Vec<Controller>,
+    pub credentials: Vec<WebAuthnCredential>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub struct AccountCredentials {
-    pub webauthn: Vec<WebAuthnCredential>,
-}
-
-#[derive(Deserialize, Debug, Clone, Serialize, PartialEq, Eq, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct WebAuthnCredential {
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Controller {
     pub id: String,
-    pub public_key: String,
+    /// The address of the Controller contract.
+    pub address: Felt,
+    pub signers: Vec<ControllerSigner>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SignerType {
+    Webauthn,
+    StarknetAccount,
+    Other(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControllerSigner {
+    pub id: String,
+    pub r#type: SignerType,
 }

--- a/slot/src/credential.rs
+++ b/slot/src/credential.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::{env, fs};
 
-use crate::account::Account;
+use crate::account::AccountInfo;
 use crate::error::Error;
 use crate::utils::{self};
 
@@ -23,12 +23,12 @@ struct LegacyCredentials {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Credentials {
     #[serde(flatten)]
-    pub account: Account,
+    pub account: AccountInfo,
     pub access_token: AccessToken,
 }
 
 impl Credentials {
-    pub fn new(account: Account, access_token: AccessToken) -> Self {
+    pub fn new(account: AccountInfo, access_token: AccessToken) -> Self {
         Self {
             account,
             access_token,
@@ -103,7 +103,7 @@ mod tests {
     use serde_json::{json, Value};
 
     use super::LegacyCredentials;
-    use crate::account::Account;
+    use crate::account::AccountInfo;
     use crate::credential::{AccessToken, Credentials, CREDENTIALS_FILE};
     use crate::utils;
     use std::fs;
@@ -133,11 +133,8 @@ mod tests {
 
         assert_eq!(account.account.id, "foo".to_string());
         assert_eq!(account.account.name, Some("".to_string()));
-        assert_eq!(account.account.credentials.webauthn[0].id, "foobar");
-        assert_eq!(
-            account.account.credentials.webauthn[0].public_key,
-            "mypublickey"
-        );
+        assert_eq!(account.account.credentials[0].id, "foobar");
+        assert_eq!(account.account.credentials[0].public_key, "mypublickey");
         assert_eq!(account.access_token.token, "oauthtoken");
         assert_eq!(account.access_token.r#type, "bearer");
 
@@ -177,7 +174,7 @@ mod tests {
             r#type: "Bearer".to_string(),
         };
 
-        let expected = Credentials::new(Account::default(), access_token);
+        let expected = Credentials::new(AccountInfo::default(), access_token);
         let _ = Credentials::store_at(&config_dir, &expected).unwrap();
 
         let actual = Credentials::load_at(config_dir).unwrap();

--- a/slot/src/credential.rs
+++ b/slot/src/credential.rs
@@ -115,14 +115,24 @@ mod tests {
         let json = json!({
           "id": "foo",
           "name": "",
-          "credentials": {
-            "webauthn": [
+          "controllers": [
+          {
+           "id": "foo",
+           "address": "0x12345",
+           "signers": [
+               {
+                   "id": "bar",
+                   "type": "WebAuthn",
+               }
+           ],
+          }
+          ],
+          "credentials": [
               {
                 "id": "foobar",
                 "publicKey": "mypublickey"
               }
-            ]
-          },
+            ],
           "access_token": {
             "token": "oauthtoken",
             "type": "bearer"

--- a/slot/src/credential.rs
+++ b/slot/src/credential.rs
@@ -94,43 +94,45 @@ mod tests {
     #[test]
     fn test_rt_static_format() {
         let json = json!({
-          "id": "foo",
-          "name": "",
-          "controllers": [
-          {
-           "id": "foo",
-           "address": "0x12345",
-           "signers": [
-               {
-                   "id": "bar",
-                   "type": "WebAuthn",
-               }
-           ],
-          }
-          ],
-          "credentials": [
-              {
-                "id": "foobar",
-                "publicKey": "mypublickey"
-              }
-            ],
-          "access_token": {
-            "token": "oauthtoken",
-            "type": "bearer"
-          }
+            "account": {
+                "id": "foo",
+                "name": "",
+                "controllers": [
+                    {
+                        "id": "foo",
+                        "address": "0x12345",
+                        "signers": [
+                            {
+                                "id": "bar",
+                                "type": "WebAuthn"
+                            }
+                        ]
+                    }
+                ],
+                "credentials": [
+                    {
+                        "id": "foobar",
+                        "publicKey": "mypublickey"
+                    }
+                ]
+            },
+            "access_token": {
+                "token": "oauthtoken",
+                "type": "bearer"
+            }
         });
 
-        let account: Credentials = serde_json::from_value(json.clone()).unwrap();
+        let credentials: Credentials = serde_json::from_value(json.clone()).unwrap();
 
-        assert_eq!(account.account.id, "foo".to_string());
-        assert_eq!(account.account.name, Some("".to_string()));
-        assert_eq!(account.account.credentials[0].id, "foobar");
-        assert_eq!(account.account.credentials[0].public_key, "mypublickey");
-        assert_eq!(account.access_token.token, "oauthtoken");
-        assert_eq!(account.access_token.r#type, "bearer");
+        assert_eq!(credentials.account.id, "foo".to_string());
+        assert_eq!(credentials.account.name, Some("".to_string()));
+        assert_eq!(credentials.account.credentials[0].id, "foobar");
+        assert_eq!(credentials.account.credentials[0].public_key, "mypublickey");
+        assert_eq!(credentials.access_token.token, "oauthtoken");
+        assert_eq!(credentials.access_token.r#type, "bearer");
 
-        let account_serialized: Value = serde_json::to_value(&account).unwrap();
-        assert_eq!(json, account_serialized);
+        let credentials_serialized: Value = serde_json::to_value(&credentials).unwrap();
+        assert_eq!(json, credentials_serialized);
     }
 
     #[test]

--- a/slot/src/error.rs
+++ b/slot/src/error.rs
@@ -10,8 +10,8 @@ pub enum Error {
     #[error("No credentials found, please authenticate with `slot auth login`")]
     Unauthorized,
 
-    #[error("Legacy credentials found, please reauthenticate with `slot auth login`")]
-    LegacyCredentials,
+    #[error("Malformed credentials, please reauthenticate with `slot auth login`")]
+    MalformedCredentials,
 
     #[error(transparent)]
     ReqwestError(#[from] reqwest::Error),

--- a/slot/src/graphql/auth/mod.rs
+++ b/slot/src/graphql/auth/mod.rs
@@ -66,7 +66,7 @@ impl From<me::MeMeControllersSigners> for account::ControllerSigner {
 impl From<me::SignerType> for account::SignerType {
     fn from(value: me::SignerType) -> Self {
         match value {
-            me::SignerType::webauthn => Self::Webauthn,
+            me::SignerType::webauthn => Self::WebAuthn,
             me::SignerType::starknet_account => Self::StarknetAccount,
             me::SignerType::Other(other) => Self::Other(other),
         }

--- a/slot/src/graphql/auth/mod.rs
+++ b/slot/src/graphql/auth/mod.rs
@@ -23,7 +23,7 @@ impl From<MeMe> for account::AccountInfo {
             .controllers
             .unwrap_or_default()
             .into_iter()
-            .map(|c| account::Controller::from(c))
+            .map(account::Controller::from)
             .collect();
 
         Self {

--- a/slot/src/session.rs
+++ b/slot/src/session.rs
@@ -416,7 +416,7 @@ impl TryFrom<&PolicyMethod> for account_sdk::account::session::hash::Policy {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::account::{Account, AccountCredentials};
+    use crate::account::AccountInfo;
     use crate::credential::{AccessToken, Credentials};
     use crate::error::Error::Unauthorized;
     use crate::session::{get_at, get_user_relative_file_path, store_at};
@@ -434,12 +434,9 @@ mod tests {
             r#type: "Bearer".to_string(),
         };
 
-        let account = Account {
-            name: None,
+        let account = AccountInfo {
             id: username.to_string(),
-            credentials: AccountCredentials {
-                webauthn: Vec::new(),
-            },
+            ..Default::default()
         };
 
         let cred = Credentials::new(account, token);


### PR DESCRIPTION
ref #104.

adding this back as Sozo, Katana expects the contract address field to exist in order to perform certain operations - [generating policies](https://github.com/dojoengine/dojo/blob/77042b16c2002cf22a1529204ae7102420dcc634/bin/sozo/src/commands/options/account/controller.rs#L80), [injecting controller account](https://github.com/dojoengine/dojo/blob/77042b16c2002cf22a1529204ae7102420dcc634/crates/katana/controller/src/lib.rs#L30-L53).

i've also changed the error handling to just return a generic `MalformedCredentials` error when the deserialization fails.