### PR TITLE
Ensure all types in a public api, are public

### DIFF
--- a/slot/src/account.rs
+++ b/slot/src/account.rs
@@ -1,4 +1,4 @@
-use crate::graphql::auth::me::MeMeCredentialsWebauthn as WebAuthnCredential;
+pub use crate::graphql::auth::me::MeMeCredentialsWebauthn as WebAuthnCredential;
 use serde::{Deserialize, Serialize};
 use starknet::core::types::Felt;
 


### PR DESCRIPTION
we're using the types in the `account.rs` for some tests in the Dojo repo

https://github.com/dojoengine/dojo/blob/77042b16c2002cf22a1529204ae7102420dcc634/crates/katana/controller/src/lib.rs#L219-L234