### PR TITLE
feat(cli): add config file support for update torii cmd

### DIFF
--- a/cli/src/command/deployments/services/torii.rs
+++ b/cli/src/command/deployments/services/torii.rs
@@ -57,4 +57,9 @@ pub struct ToriiUpdateArgs {
     #[arg(long, short, value_name = "version")]
     #[arg(help = "Service version to use.")]
     pub version: Option<String>,
+
+    #[arg(long)]
+    #[arg(help = "A config file ")]
+    #[arg(value_name = "config-file")]
+    pub config_file: Option<String>,
 }

--- a/slot/schema.json
+++ b/slot/schema.json
@@ -16612,6 +16612,16 @@
                 "name": "UpdateKatanaConfigInput",
                 "ofType": null
               }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "torii",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "UpdateToriiConfigInput",
+                "ofType": null
+              }
             }
           ],
           "interfaces": [],
@@ -16662,6 +16672,27 @@
           "interfaces": [],
           "kind": "INPUT_OBJECT",
           "name": "UpdateServiceInput",
+          "possibleTypes": []
+        },
+        {
+          "description": null,
+          "enumValues": [],
+          "fields": [],
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "configFile",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "interfaces": [],
+          "kind": "INPUT_OBJECT",
+          "name": "UpdateToriiConfigInput",
           "possibleTypes": []
         },
         {

--- a/slot/src/graphql/deployments/update.graphql
+++ b/slot/src/graphql/deployments/update.graphql
@@ -17,6 +17,7 @@ mutation UpdateDeployment(
     }
 
     ... on ToriiConfig {
+      configFile
       graphql
       grpc
       rpc


### PR DESCRIPTION
Added the ability to specify a config file for the Torii service on update. The file is read and encoded in base64 for the update process.