### PR TITLE
feat(katana): add config file support for katana

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4309,7 +4309,6 @@ version = "0.21.0"
 dependencies = [
  "anyhow",
  "axum",
- "base64 0.21.7",
  "clap",
  "ctrlc",
  "dialoguer",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,7 +27,6 @@ starknet.workspace = true
 shellexpand = "3.1.0"
 url.workspace = true
 rand.workspace = true
-base64 = "0.21.7"
 
 [[bin]]
 name = "slot"

--- a/cli/src/command/deployments/services/katana.rs
+++ b/cli/src/command/deployments/services/katana.rs
@@ -55,6 +55,11 @@ pub struct KatanaCreateArgs {
     #[arg(long)]
     #[arg(help = "Enable Katana dev mode for specific endpoints.")]
     pub dev: bool,
+
+    #[arg(long)]
+    #[arg(help = "A config file ")]
+    #[arg(value_name = "config-file")]
+    pub config_file: Option<String>,
 }
 
 #[derive(Debug, Args, serde::Serialize)]
@@ -95,6 +100,11 @@ pub struct KatanaUpdateArgs {
     #[arg(long)]
     #[arg(help = "Enable Katana dev mode for specific endpoints.")]
     pub dev: bool,
+
+    #[arg(long)]
+    #[arg(help = "A config file ")]
+    #[arg(value_name = "config-file")]
+    pub config_file: Option<String>,
 }
 
 #[derive(Debug, Args, serde::Serialize)]

--- a/slot/schema.json
+++ b/slot/schema.json
@@ -5137,6 +5137,16 @@
                 "name": "Boolean",
                 "ofType": null
               }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "configFile",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             }
           ],
           "interfaces": [],
@@ -10708,6 +10718,18 @@
                   "name": "String",
                   "ofType": null
                 }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "configFile",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             }
           ],
@@ -16589,6 +16611,16 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "configFile",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             }

--- a/slot/src/graphql/deployments/update.graphql
+++ b/slot/src/graphql/deployments/update.graphql
@@ -13,6 +13,7 @@ mutation UpdateDeployment(
     __typename
 
     ... on KatanaConfig {
+      configFile
       rpc
     }
 

--- a/slot/src/lib.rs
+++ b/slot/src/lib.rs
@@ -5,6 +5,7 @@ pub mod api;
 pub mod browser;
 pub mod credential;
 pub mod graphql;
+pub mod read;
 pub mod server;
 pub mod session;
 pub mod vars;

--- a/slot/src/read.rs
+++ b/slot/src/read.rs
@@ -1,0 +1,12 @@
+use base64::{engine, Engine};
+
+pub fn read_and_encode_file_as_base64(file_path: Option<String>) -> anyhow::Result<Option<String>> {
+    if let Some(path) = file_path {
+        let file_contents = std::fs::read(path)?;
+        Ok(Some(
+            engine::general_purpose::STANDARD.encode(file_contents),
+        ))
+    } else {
+        Ok(None)
+    }
+}


### PR DESCRIPTION
Introduced a config file option in deployment commands to allow users to specify and encode configuration files in base64.