### PR TITLE
fix(deployments): correct RPC field duplication error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 torii.toml
+katana.toml

--- a/cli/src/command/deployments/create.rs
+++ b/cli/src/command/deployments/create.rs
@@ -71,7 +71,7 @@ impl CreateArgs {
                     config: Some(CreateServiceConfigInput {
                         katana: None,
                         torii: Some(CreateToriiConfigInput {
-                            rpc: Some(config.rpc.clone().unwrap_or("".to_string())),
+                            rpc: config.clone().rpc,
                             // provide world if provided
                             world: match &config.world {
                                 Some(world) => format!("{:#x}", world).into(),


### PR DESCRIPTION
Updated the RPC field in CreateToriiConfigInput to use the cloned config directly, resolving the issue of incorrect duplication.