### PR TITLE
feat(cli): add version update notification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3051,6 +3051,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
 name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7685,7 +7694,7 @@ dependencies = [
 
 [[package]]
 name = "slot"
-version = "0.25.3"
+version = "0.25.2"
 dependencies = [
  "account_sdk",
  "anyhow",
@@ -7711,7 +7720,7 @@ dependencies = [
 
 [[package]]
 name = "slot-cli"
-version = "0.25.3"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -7726,12 +7735,13 @@ dependencies = [
  "katana-primitives",
  "log",
  "serde",
- "slot 0.25.3",
+ "slot 0.25.2",
  "starknet",
  "thiserror",
  "tokio",
  "toml",
  "torii-cli",
+ "update-informer",
  "url",
 ]
 
@@ -9250,6 +9260,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "update-informer"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f8811797a24ff123db3c6e1087aa42551d03d772b3724be421ad063da1f5f3f"
+dependencies = [
+ "directories",
+ "semver 1.0.23",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -31,6 +31,7 @@ slot.workspace = true
 starknet.workspace = true
 toml = "0.8"
 url.workspace = true
+update-informer = { version = "1.1", default-features = false, features = ["github"] }
 
 [[bin]]
 name = "slot"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,6 +4,8 @@ mod command;
 
 use crate::command::Command;
 use clap::Parser;
+use colored::*;
+use update_informer::{registry, Check};
 
 /// Slot CLI for Cartridge
 #[derive(Parser, Debug)]
@@ -18,6 +20,10 @@ async fn main() {
     env_logger::init();
     let cli = Cli::parse();
 
+    let name = "cartridge-gg/slot";
+    let current = env!("CARGO_PKG_VERSION");
+    let informer = update_informer::new(registry::GitHub, name, current);
+
     match &cli.command.run().await {
         Ok(_) => {}
         Err(e) => {
@@ -25,4 +31,20 @@ async fn main() {
             std::process::exit(1);
         }
     }
+
+    if let Some(version) = informer.check_version().ok().flatten() {
+        notify_new_version(current, version.to_string().as_str());
+    }
+}
+
+fn notify_new_version(current_version: &str, latest_version: &str) {
+    println!(
+        "\n{} {}{} → {}",
+        "Slot CLI update available:".bold(),
+        "v".red().bold(),
+        current_version.red().bold(),
+        latest_version.green().bold()
+    );
+    println!("To upgrade, run: {}", "`slotup`".cyan().bold());
+    println!("\n")
 }


### PR DESCRIPTION
Implement version check and notification using update-informer crate. This informs users of new versions with formatted messages to encourage updates. Updated Cargo.toml and Cargo.lock files to include new dependencies.

<img width="422" alt="image" src="https://github.com/user-attachments/assets/ffc89ba0-8977-412c-85de-a4ae6db13aef">
