### PR TITLE
fix(cli): add missing feature in update-informer config

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -31,7 +31,7 @@ slot.workspace = true
 starknet.workspace = true
 toml = "0.8"
 url.workspace = true
-update-informer = { version = "1.1", default-features = false, features = ["github"] }
+update-informer = { version = "1.1", default-features = false, features = ["ureq", "github"] }
 
 [[bin]]
 name = "slot"


### PR DESCRIPTION
Include 'ureq' feature in update-informer to ensure proper functionality within the CLI.