### PR TITLE
fix: ensure the config is provided before updating torii

### DIFF
--- a/cli/src/command/deployments/update.rs
+++ b/cli/src/command/deployments/update.rs
@@ -55,6 +55,20 @@ impl UpdateArgs {
                 }
             }
             UpdateServiceCommands::Torii(config) => {
+                // Enforce the use of the `--config` flag, to have the infra
+                // actually override the config file with the new behavior without relying
+                // on default values.
+                if config.torii_args.config.is_none() {
+                    let describe_command = format!(
+                        "slot deployments describe {project} torii",
+                        project = self.project
+                    );
+
+                    return Err(anyhow::anyhow!(
+                        "The `--config` flag is required to update the torii service and ensure the new configuration is applied. If you don't have a config file yet, you can use `{describe_command}` to inspect the current one."
+                    ));
+                }
+
                 let service_config =
                     toml::to_string(&ToriiArgsConfig::try_from(config.torii_args.clone())?)?;
 


### PR DESCRIPTION
@steebchen in this PR we enforce a configuration file for Torii. This is what it looks like.

Please let me know your thoughts about it and let's iterate. 👍 