### PR TITLE
feat(cli): add update check interval configuration

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -22,7 +22,8 @@ async fn main() {
 
     let name = "cartridge-gg/slot";
     let current = env!("CARGO_PKG_VERSION");
-    let informer = update_informer::new(registry::GitHub, name, current);
+    let informer = update_informer::new(registry::GitHub, name, current)
+        .interval(std::time::Duration::from_secs(60 * 60));
 
     match &cli.command.run().await {
         Ok(_) => {}


### PR DESCRIPTION
Set update_informer to check for updates every hour by configuring the interval duration, enhancing update management.