### PR TITLE
feat(auth): add fund command to support user account funding

### DIFF
--- a/cli/src/command/auth/fund.rs
+++ b/cli/src/command/auth/fund.rs
@@ -1,0 +1,18 @@
+use anyhow::Result;
+use clap::Args;
+use slot::{browser, vars};
+
+#[derive(Debug, Args)]
+pub struct FundArgs;
+
+impl FundArgs {
+    pub async fn run(&self) -> Result<()> {
+        let url = vars::get_cartridge_keychain_url();
+
+        let url = format!("{url}/slot/fund");
+
+        browser::open(&url)?;
+
+        Ok(())
+    }
+}

--- a/cli/src/command/auth/mod.rs
+++ b/cli/src/command/auth/mod.rs
@@ -1,10 +1,12 @@
 use self::{email::EmailArgs, info::InfoArgs, login::LoginArgs};
 use crate::command::auth::billing::BillingArgs;
+use crate::command::auth::fund::FundArgs;
 use anyhow::Result;
 use clap::Subcommand;
 
 mod billing;
 mod email;
+mod fund;
 mod info;
 mod login;
 mod session;
@@ -23,6 +25,9 @@ pub enum Auth {
     #[command(about = "Manage slot billing for the authenticated user.")]
     EnableSlotBilling(BillingArgs),
 
+    #[command(about = "Fund the authenticated user's account.")]
+    Fund(FundArgs),
+
     // Mostly for testing purposes, will eventually turn it into a library call from `sozo`.
     #[command(hide = true)]
     CreateSession(session::CreateSession),
@@ -36,6 +41,7 @@ impl Auth {
             Auth::CreateSession(args) => args.run().await,
             Auth::SetEmail(args) => args.run().await,
             Auth::EnableSlotBilling(args) => args.run().await,
+            Auth::Fund(args) => args.run().await,
         }
     }
 }


### PR DESCRIPTION
Introduced a new "Fund" command for authenticated users. This command opens the browser to direct users to the funding page.