### PR TITLE
chore(scripts): add param for local/prod schema pull

### DIFF
--- a/scripts/pull_schema.sh
+++ b/scripts/pull_schema.sh
@@ -3,5 +3,11 @@
 # https://github.com/graphql-rust/graphql-client/blob/main/graphql_client_cli/README.md
 # cargo install graphql_client_cli
 
-graphql-client introspect-schema --output slot/schema.json https://api.cartridge.gg/query
-#graphql-client introspect-schema --output slot/schema.json http://localhost:8000/query
+# check if param to pull schema is set to "local"
+if [ "$1" = "local" ]; then
+	graphql-client introspect-schema --output slot/schema.json http://localhost:8000/query
+elif [ "$1" = "prod" ]; then
+	graphql-client introspect-schema --output slot/schema.json https://api.cartridge.gg/query
+else
+	echo "usage: pull_schema.sh [local|prod]"
+fi


### PR DESCRIPTION
Allow specifying "local" or "prod" to pull schema from the desired environment. Display usage instructions for invalid inputs.