### PR TITLE
feat(katana): add persistent mode and network options

### DIFF
--- a/cli/src/command/deployments/create.rs
+++ b/cli/src/command/deployments/create.rs
@@ -44,6 +44,8 @@ impl CreateArgs {
     pub async fn run(&self) -> Result<()> {
         let service = match &self.create_commands {
             CreateServiceCommands::Katana(config) => {
+                config.validate()?;
+
                 let service_config =
                     toml::to_string(&NodeArgsConfig::try_from(config.node_args.clone())?)?;
 
@@ -57,6 +59,10 @@ impl CreateArgs {
                     type_: DeploymentService::katana,
                     version: config.version.clone(),
                     config: slot::read::base64_encode_string(&service_config),
+                    katana: Some(KatanaCreateInput {
+                        persistent: Some(config.persistent),
+                        network: config.network.clone(),
+                    }),
                 }
             }
             CreateServiceCommands::Torii(config) => {
@@ -73,6 +79,7 @@ impl CreateArgs {
                     type_: DeploymentService::torii,
                     version: config.version.clone(),
                     config: slot::read::base64_encode_string(&service_config),
+                    katana: None,
                 }
             }
         };

--- a/cli/src/command/deployments/services/katana.rs
+++ b/cli/src/command/deployments/services/katana.rs
@@ -1,3 +1,4 @@
+use anyhow::anyhow;
 use clap::Args;
 use katana_cli::NodeArgs;
 
@@ -10,6 +11,26 @@ pub struct KatanaCreateArgs {
 
     #[command(flatten)]
     pub node_args: NodeArgs,
+
+    #[arg(long, short, value_name = "persistent mode")]
+    #[arg(help = "Whether to run the service in persistent mode (saya).")]
+    pub persistent: bool,
+
+    #[arg(long, short, value_name = "network")]
+    #[arg(help = "Network to use for the service. Only in persistent (saya) mode.")]
+    pub network: Option<String>,
+}
+
+impl KatanaCreateArgs {
+    /// Validate the provided arguments
+    pub fn validate(&self) -> Result<(), anyhow::Error> {
+        if self.network.is_some() && !self.persistent {
+            return Err(anyhow!(
+                "The `network` option can only be supplied when `--persistent` is enabled.",
+            ));
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Args, serde::Serialize)]

--- a/slot/schema.json
+++ b/slot/schema.json
@@ -6284,6 +6284,16 @@
                   "ofType": null
                 }
               }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "katana",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "KatanaCreateInput",
+                "ofType": null
+              }
             }
           ],
           "interfaces": [],
@@ -11693,6 +11703,37 @@
           "interfaces": [],
           "kind": "SCALAR",
           "name": "JSON",
+          "possibleTypes": []
+        },
+        {
+          "description": null,
+          "enumValues": [],
+          "fields": [],
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "persistent",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "network",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "interfaces": [],
+          "kind": "INPUT_OBJECT",
+          "name": "KatanaCreateInput",
           "possibleTypes": []
         },
         {


### PR DESCRIPTION
Introduce `persistent` and `network` options to Katana service. The `network` option is validated to require `--persistent` mode.