### PR TITLE
feat(katana): add saya option for provable mode

### DIFF
--- a/cli/src/command/deployments/create.rs
+++ b/cli/src/command/deployments/create.rs
@@ -61,8 +61,8 @@ impl CreateArgs {
                     config: slot::read::base64_encode_string(&service_config),
                     katana: Some(KatanaCreateInput {
                         provable: Some(config.provable),
-                        saya: Some(config.saya),
                         network: config.network.clone(),
+                        saya: Some(config.saya),
                     }),
                 }
             }

--- a/cli/src/command/deployments/create.rs
+++ b/cli/src/command/deployments/create.rs
@@ -61,6 +61,7 @@ impl CreateArgs {
                     config: slot::read::base64_encode_string(&service_config),
                     katana: Some(KatanaCreateInput {
                         provable: Some(config.provable),
+                        saya: Some(config.saya),
                         network: config.network.clone(),
                     }),
                 }

--- a/cli/src/command/deployments/create.rs
+++ b/cli/src/command/deployments/create.rs
@@ -60,7 +60,7 @@ impl CreateArgs {
                     version: config.version.clone(),
                     config: slot::read::base64_encode_string(&service_config),
                     katana: Some(KatanaCreateInput {
-                        persistent: Some(config.persistent),
+                        provable: Some(config.provable),
                         network: config.network.clone(),
                     }),
                 }

--- a/cli/src/command/deployments/services/katana.rs
+++ b/cli/src/command/deployments/services/katana.rs
@@ -20,9 +20,11 @@ pub struct KatanaCreateArgs {
     #[arg(help = "Network to use for the service. Only in provable mode.")]
     pub network: Option<String>,
 
-    #[arg(long, short, value_name = "network")]
-    #[arg(help = "Whether to start a saya instance alongside the provable Katana. Only in provable mode.")]
-    pub saya: Option<String>,
+    #[arg(long, short, value_name = "saya")]
+    #[arg(
+        help = "Whether to start a saya instance alongside the provable Katana. Only in provable mode."
+    )]
+    pub saya: bool,
 }
 
 impl KatanaCreateArgs {
@@ -33,7 +35,7 @@ impl KatanaCreateArgs {
                 "The `network` option can only be supplied when `--provable` is enabled.",
             ));
         }
-        if self.saya.is_some() && !self.provable {
+        if self.saya && !self.provable {
             return Err(anyhow!(
                 "The `saya` option can only be supplied when `--provable` is enabled.",
             ));

--- a/cli/src/command/deployments/services/katana.rs
+++ b/cli/src/command/deployments/services/katana.rs
@@ -21,7 +21,7 @@ pub struct KatanaCreateArgs {
     pub network: Option<String>,
 
     #[arg(long, short, value_name = "network")]
-    #[arg(help = "Whether to use saya. Only in provable mode.")]
+    #[arg(help = "Whether to start a saya instance alongside the provable Katana. Only in provable mode.")]
     pub saya: Option<String>,
 }
 

--- a/cli/src/command/deployments/services/katana.rs
+++ b/cli/src/command/deployments/services/katana.rs
@@ -13,12 +13,16 @@ pub struct KatanaCreateArgs {
     pub node_args: NodeArgs,
 
     #[arg(long, short, value_name = "provable mode")]
-    #[arg(help = "Whether to run the service in provable mode (saya).")]
+    #[arg(help = "Whether to run the service in provable mode.")]
     pub provable: bool,
 
     #[arg(long, short, value_name = "network")]
-    #[arg(help = "Network to use for the service. Only in provable (saya) mode.")]
+    #[arg(help = "Network to use for the service. Only in provable mode.")]
     pub network: Option<String>,
+
+    #[arg(long, short, value_name = "network")]
+    #[arg(help = "Whether to use saya. Only in provable mode.")]
+    pub saya: Option<String>,
 }
 
 impl KatanaCreateArgs {
@@ -27,6 +31,11 @@ impl KatanaCreateArgs {
         if self.network.is_some() && !self.provable {
             return Err(anyhow!(
                 "The `network` option can only be supplied when `--provable` is enabled.",
+            ));
+        }
+        if self.saya.is_some() && !self.provable {
+            return Err(anyhow!(
+                "The `saya` option can only be supplied when `--provable` is enabled.",
             ));
         }
         Ok(())

--- a/cli/src/command/deployments/services/katana.rs
+++ b/cli/src/command/deployments/services/katana.rs
@@ -12,21 +12,21 @@ pub struct KatanaCreateArgs {
     #[command(flatten)]
     pub node_args: NodeArgs,
 
-    #[arg(long, short, value_name = "persistent mode")]
-    #[arg(help = "Whether to run the service in persistent mode (saya).")]
-    pub persistent: bool,
+    #[arg(long, short, value_name = "provable mode")]
+    #[arg(help = "Whether to run the service in provable mode (saya).")]
+    pub provable: bool,
 
     #[arg(long, short, value_name = "network")]
-    #[arg(help = "Network to use for the service. Only in persistent (saya) mode.")]
+    #[arg(help = "Network to use for the service. Only in provable (saya) mode.")]
     pub network: Option<String>,
 }
 
 impl KatanaCreateArgs {
     /// Validate the provided arguments
     pub fn validate(&self) -> Result<(), anyhow::Error> {
-        if self.network.is_some() && !self.persistent {
+        if self.network.is_some() && !self.provable {
             return Err(anyhow!(
-                "The `network` option can only be supplied when `--persistent` is enabled.",
+                "The `network` option can only be supplied when `--provable` is enabled.",
             ));
         }
         Ok(())

--- a/slot/schema.json
+++ b/slot/schema.json
@@ -11913,6 +11913,16 @@
             {
               "defaultValue": null,
               "description": null,
+              "name": "saya",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
               "name": "network",
               "type": {
                 "kind": "SCALAR",

--- a/slot/schema.json
+++ b/slot/schema.json
@@ -11903,7 +11903,7 @@
             {
               "defaultValue": null,
               "description": null,
-              "name": "persistent",
+              "name": "provable",
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",


### PR DESCRIPTION
Added a new `saya` option to Katana services, usable only in
provable mode. Updated validation logic and schema for compatibility.