### PR TITLE
ci: adjust release artifact naming and downloading

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          name: artifacts-${{ matrix.job.target }}
           path: ${{ steps.artifacts.outputs.file_name }}
           retention-days: 1
 
@@ -125,8 +125,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          pattern: artifacts-*
           path: artifacts
+          merge-multiple: true
       - id: version_info
         run: |
           cargo install cargo-get


### PR DESCRIPTION
Update artifact naming to include job target and enable pattern-based artifact download with merged artifacts handling.