### PR TITLE
feat(deployments): add "Insane" tier and remove "Rare" tier

### DIFF
--- a/cli/src/command/deployments/create.rs
+++ b/cli/src/command/deployments/create.rs
@@ -88,8 +88,8 @@ impl CreateArgs {
         let tier = match &self.tier {
             Tier::Basic => DeploymentTier::basic,
             Tier::Common => DeploymentTier::common,
-            Tier::Rare => DeploymentTier::rare,
             Tier::Epic => DeploymentTier::epic,
+            Tier::Insane => DeploymentTier::insane,
         };
 
         let request_body = CreateDeployment::build_query(Variables {

--- a/cli/src/command/deployments/mod.rs
+++ b/cli/src/command/deployments/mod.rs
@@ -54,8 +54,8 @@ impl Deployments {
 pub enum Tier {
     Basic,
     Common,
-    Rare,
     Epic,
+    Insane,
 }
 
 /// Returns the service url for a given project and service.

--- a/cli/src/command/deployments/update.rs
+++ b/cli/src/command/deployments/update.rs
@@ -70,8 +70,8 @@ impl UpdateArgs {
             None => None,
             Some(Tier::Basic) => Some(DeploymentTier::basic),
             Some(Tier::Common) => Some(DeploymentTier::common),
-            Some(Tier::Rare) => Some(DeploymentTier::rare),
             Some(Tier::Epic) => Some(DeploymentTier::epic),
+            Some(Tier::Insane) => Some(DeploymentTier::insane),
         };
 
         let request_body = UpdateDeployment::build_query(Variables {

--- a/slot/schema.json
+++ b/slot/schema.json
@@ -8827,18 +8827,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "uncommon"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "rare"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "epic"
             },
             {


### PR DESCRIPTION
Updated CLI commands and schema to replace "Rare" tier with the new "Insane" tier for deployments. Removed deprecated "uncommon" tier from schema.