### PR TITLE
feat(cli): add support for team creation and transfer

### DIFF
--- a/cli/src/command/deployments/mod.rs
+++ b/cli/src/command/deployments/mod.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Subcommand;
 use colored::*;
-
+use crate::command::deployments::transfer::TransferArgs;
 use self::{
     accounts::AccountsArgs, create::CreateArgs, delete::DeleteArgs, describe::DescribeArgs,
     list::ListArgs, logs::LogsArgs, update::UpdateArgs,
@@ -21,18 +21,28 @@ pub const CARTRIDGE_BASE_URL: &str = "https://api.cartridge.gg/x";
 
 #[derive(Subcommand, Debug)]
 pub enum Deployments {
+
     #[command(about = "Create a new deployment.")]
     Create(CreateArgs),
+
     #[command(about = "Delete a deployment.")]
     Delete(DeleteArgs),
+
     #[command(about = "Update a deployment.")]
     Update(UpdateArgs),
+
     #[command(about = "Describe a deployment's configuration.")]
     Describe(DescribeArgs),
+
     #[command(about = "List all deployments.", aliases = ["ls"])]
     List(ListArgs),
+
+    #[command(about = "Transfer a deployment.")]
+    Transfer(TransferArgs),
+
     #[command(about = "Fetch logs for a deployment.")]
     Logs(LogsArgs),
+
     #[command(about = "Fetch Katana accounts.")]
     Accounts(AccountsArgs),
 }
@@ -45,6 +55,7 @@ impl Deployments {
             Deployments::Update(args) => args.run().await,
             Deployments::Describe(args) => args.run().await,
             Deployments::List(args) => args.run().await,
+            Deployments::Transfer(args) => args.run().await,
             Deployments::Logs(args) => args.run().await,
             Deployments::Accounts(args) => args.run().await,
         }

--- a/cli/src/command/deployments/mod.rs
+++ b/cli/src/command/deployments/mod.rs
@@ -1,11 +1,11 @@
-use anyhow::Result;
-use clap::Subcommand;
-use colored::*;
-use crate::command::deployments::transfer::TransferArgs;
 use self::{
     accounts::AccountsArgs, create::CreateArgs, delete::DeleteArgs, describe::DescribeArgs,
     list::ListArgs, logs::LogsArgs, update::UpdateArgs,
 };
+use crate::command::deployments::transfer::TransferArgs;
+use anyhow::Result;
+use clap::Subcommand;
+use colored::*;
 
 mod accounts;
 mod create;
@@ -21,7 +21,6 @@ pub const CARTRIDGE_BASE_URL: &str = "https://api.cartridge.gg/x";
 
 #[derive(Subcommand, Debug)]
 pub enum Deployments {
-
     #[command(about = "Create a new deployment.")]
     Create(CreateArgs),
 

--- a/cli/src/command/deployments/mod.rs
+++ b/cli/src/command/deployments/mod.rs
@@ -14,6 +14,7 @@ mod describe;
 mod list;
 mod logs;
 mod services;
+mod transfer;
 mod update;
 
 pub const CARTRIDGE_BASE_URL: &str = "https://api.cartridge.gg/x";

--- a/cli/src/command/deployments/transfer.rs
+++ b/cli/src/command/deployments/transfer.rs
@@ -1,0 +1,64 @@
+use anyhow::Result;
+use clap::Args;
+use dialoguer::theme::ColorfulTheme;
+use dialoguer::Confirm;
+use slot::graphql::deployments::{transfer_deployment::*, TransferDeployment};
+use slot::graphql::GraphQLQuery;
+use slot::{api::Client, credential::Credentials};
+
+#[derive(clap::ValueEnum, Clone, Debug, serde::Serialize)]
+pub enum Service {
+    Katana,
+    Torii,
+}
+
+#[derive(Debug, Args)]
+#[command(next_help_heading = "Transfer options")]
+pub struct TransferArgs {
+    #[arg(help = "The name of the project.")]
+    pub project: String,
+
+    #[arg(help = "The name of the service.")]
+    pub service: Service,
+
+    #[arg(help = "The name of the team.")]
+    pub team: String,
+
+    #[arg(help = "Force Transfer without confirmation", short('f'))]
+    pub force: bool,
+}
+
+impl TransferArgs {
+    pub async fn run(&self) -> Result<()> {
+        if !self.force {
+            let confirmation = Confirm::with_theme(&ColorfulTheme::default())
+                .with_prompt(format!(
+                    "Please confirm to Transfer {} {:?} to {}",
+                    &self.project, &self.service, &self.team
+                ))
+                .default(false)
+                .show_default(true)
+                .wait_for_newline(true)
+                .interact()
+                .unwrap();
+
+            if !confirmation {
+                return Ok(());
+            }
+        }
+
+        let request_body = TransferDeployment::build_query(Variables {
+            name: self.project.clone(),
+            team: self.team.clone(),
+        });
+
+        let user = Credentials::load()?;
+        let client = Client::new_with_token(user.access_token);
+
+        let _data: ResponseData = client.query(&request_body).await?;
+
+        println!("Transfer success 🚀");
+
+        Ok(())
+    }
+}

--- a/cli/src/command/deployments/transfer.rs
+++ b/cli/src/command/deployments/transfer.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use clap::Args;
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::Confirm;
+use slot::graphql::deployments::transfer_deployment::DeploymentService;
 use slot::graphql::deployments::{transfer_deployment::*, TransferDeployment};
 use slot::graphql::GraphQLQuery;
 use slot::{api::Client, credential::Credentials};
@@ -33,7 +34,7 @@ impl TransferArgs {
         if !self.force {
             let confirmation = Confirm::with_theme(&ColorfulTheme::default())
                 .with_prompt(format!(
-                    "Please confirm to Transfer {} {:?} to {}",
+                    "Please confirm to transfer {} {:?} to {}",
                     &self.project, &self.service, &self.team
                 ))
                 .default(false)
@@ -47,9 +48,15 @@ impl TransferArgs {
             }
         }
 
+        let service = match &self.service {
+            Service::Katana => DeploymentService::katana,
+            Service::Torii => DeploymentService::torii,
+        };
+
         let request_body = TransferDeployment::build_query(Variables {
             name: self.project.clone(),
             team: self.team.clone(),
+            service,
         });
 
         let user = Credentials::load()?;

--- a/cli/src/command/mod.rs
+++ b/cli/src/command/mod.rs
@@ -8,6 +8,7 @@ use clap::Subcommand;
 use auth::Auth;
 use deployments::Deployments;
 use teams::Teams;
+use crate::command::teams::create::CreateTeamArgs;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Subcommand, Debug)]
@@ -15,9 +16,11 @@ pub enum Command {
     #[command(subcommand)]
     #[command(about = "Manage auth credentials for the Slot CLI.", aliases = ["a"])]
     Auth(Auth),
+
     #[command(subcommand)]
     #[command(about = "Manage Slot deployments.", aliases = ["d"])]
     Deployments(Deployments),
+
     #[command(about = "Manage Slot team.", aliases = ["t"])]
     Teams(Teams),
 }

--- a/cli/src/command/mod.rs
+++ b/cli/src/command/mod.rs
@@ -8,7 +8,6 @@ use clap::Subcommand;
 use auth::Auth;
 use deployments::Deployments;
 use teams::Teams;
-use crate::command::teams::create::CreateTeamArgs;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Subcommand, Debug)]

--- a/cli/src/command/teams/create.rs
+++ b/cli/src/command/teams/create.rs
@@ -2,30 +2,24 @@ use anyhow::Result;
 use clap::Args;
 use slot::api::Client;
 use slot::credential::Credentials;
-use slot::graphql::GraphQLQuery;
-use slot::graphql::team::CreateTeam;
-use slot::graphql::team::team_member_add::Variables;
 use slot::graphql::team::create_team;
+use slot::graphql::team::CreateTeam;
+use slot::graphql::GraphQLQuery;
 
 #[derive(Debug, Args, serde::Serialize)]
 #[command(next_help_heading = "Team create options")]
-pub struct CreateTeamArgs {
-    #[arg(help = "Name of the team to create.")]
-    pub name: String,
-}
+pub struct CreateTeamArgs {}
 
 impl CreateTeamArgs {
     pub async fn run(&self, team: String) -> Result<()> {
-        let request_body = CreateTeam::build_query(create_team::Variables {
-            name: self.name.clone(),
-        });
+        let request_body = CreateTeam::build_query(create_team::Variables { name: team.clone() });
 
         let credentials = Credentials::load()?;
         let client = Client::new_with_token(credentials.access_token);
 
         let data: create_team::ResponseData = client.query(&request_body).await?;
 
-        println!("Team created successfully 🚀");
+        println!("Team {} created successfully 🚀", data.create_team.name);
 
         Ok(())
     }

--- a/cli/src/command/teams/create.rs
+++ b/cli/src/command/teams/create.rs
@@ -5,6 +5,7 @@ use slot::credential::Credentials;
 use slot::graphql::GraphQLQuery;
 use slot::graphql::team::CreateTeam;
 use slot::graphql::team::team_member_add::Variables;
+use slot::graphql::team::create_team;
 
 #[derive(Debug, Args, serde::Serialize)]
 #[command(next_help_heading = "Team create options")]
@@ -15,14 +16,14 @@ pub struct CreateTeamArgs {
 
 impl CreateTeamArgs {
     pub async fn run(&self, team: String) -> Result<()> {
-        let request_body = CreateTeam::build_query(Variables {
-            name: team,
+        let request_body = CreateTeam::build_query(create_team::Variables {
+            name: self.name.clone(),
         });
 
         let credentials = Credentials::load()?;
         let client = Client::new_with_token(credentials.access_token);
 
-        let data: ResponseData = client.query(&request_body).await?;
+        let data: create_team::ResponseData = client.query(&request_body).await?;
 
         println!("Team created successfully 🚀");
 

--- a/cli/src/command/teams/create.rs
+++ b/cli/src/command/teams/create.rs
@@ -1,0 +1,31 @@
+use anyhow::Result;
+use clap::Args;
+use slot::api::Client;
+use slot::credential::Credentials;
+use slot::graphql::GraphQLQuery;
+use slot::graphql::team::CreateTeam;
+use slot::graphql::team::team_member_add::Variables;
+
+#[derive(Debug, Args, serde::Serialize)]
+#[command(next_help_heading = "Team create options")]
+pub struct CreateTeamArgs {
+    #[arg(help = "Name of the team to create.")]
+    pub name: String,
+}
+
+impl CreateTeamArgs {
+    pub async fn run(&self, team: String) -> Result<()> {
+        let request_body = CreateTeam::build_query(Variables {
+            name: team,
+        });
+
+        let credentials = Credentials::load()?;
+        let client = Client::new_with_token(credentials.access_token);
+
+        let data: ResponseData = client.query(&request_body).await?;
+
+        println!("Team created successfully 🚀");
+
+        Ok(())
+    }
+}

--- a/cli/src/command/teams/mod.rs
+++ b/cli/src/command/teams/mod.rs
@@ -1,10 +1,10 @@
+use self::members::{TeamAddArgs, TeamListArgs, TeamRemoveArgs};
+use crate::command::teams::create::CreateTeamArgs;
 use anyhow::Result;
 use clap::{Args, Subcommand};
-use crate::command::teams::create::CreateTeamArgs;
-use self::members::{TeamAddArgs, TeamListArgs, TeamRemoveArgs};
 
-mod members;
 mod create;
+mod members;
 
 #[derive(Debug, Args)]
 #[command(next_help_heading = "Team options")]

--- a/cli/src/command/teams/mod.rs
+++ b/cli/src/command/teams/mod.rs
@@ -1,9 +1,10 @@
 use anyhow::Result;
 use clap::{Args, Subcommand};
-
+use crate::command::teams::create::CreateTeamArgs;
 use self::members::{TeamAddArgs, TeamListArgs, TeamRemoveArgs};
 
 mod members;
+mod create;
 
 #[derive(Debug, Args)]
 #[command(next_help_heading = "Team options")]
@@ -17,10 +18,15 @@ pub struct Teams {
 
 #[derive(Subcommand, Debug)]
 pub enum TeamsCommands {
+    #[command(about = "Create a new team.")]
+    Create(CreateTeamArgs),
+
     #[command(about = "List team members.", aliases = ["ls"])]
     List(TeamListArgs),
+
     #[command(about = "Add a new team member.")]
     Add(TeamAddArgs),
+
     #[command(about = "Remove a team member.")]
     Remove(TeamRemoveArgs),
 }
@@ -31,6 +37,7 @@ impl Teams {
             TeamsCommands::List(args) => args.run(self.name.clone()).await,
             TeamsCommands::Add(args) => args.run(self.name.clone()).await,
             TeamsCommands::Remove(args) => args.run(self.name.clone()).await,
+            TeamsCommands::Create(args) => args.run(self.name.clone()).await,
         }
     }
 }

--- a/slot/schema.json
+++ b/slot/schema.json
@@ -13421,6 +13421,16 @@
                       }
                     }
                   }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "team",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
                 }
               ],
               "deprecationReason": null,
@@ -13552,6 +13562,65 @@
                 {
                   "defaultValue": null,
                   "description": null,
+                  "name": "name",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "service",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "DeploymentService",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "team",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "transferDeployment",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
                   "name": "req",
                   "type": {
                     "kind": "NON_NULL",
@@ -13635,6 +13704,37 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "name",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "createTeam",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Team",
                   "ofType": null
                 }
               }
@@ -15765,6 +15865,81 @@
               "description": null,
               "isDeprecated": false,
               "name": "priceByAddresses",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Price",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "addresses",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "SCALAR",
+                          "name": "String",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "start",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "end",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "pricePeriodByAddresses",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,

--- a/slot/src/graphql/deployments/mod.rs
+++ b/slot/src/graphql/deployments/mod.rs
@@ -9,6 +9,7 @@ mod delete;
 mod describe;
 mod list;
 mod logs;
+mod transfer;
 mod update;
 
 pub use accounts::*;
@@ -17,4 +18,5 @@ pub use delete::*;
 pub use describe::*;
 pub use list::*;
 pub use logs::*;
+pub use transfer::*;
 pub use update::*;

--- a/slot/src/graphql/deployments/transfer.graphql
+++ b/slot/src/graphql/deployments/transfer.graphql
@@ -1,0 +1,3 @@
+mutation TransferDeployment($name: String!, $team: String!) {
+	transferDeployment(name: $name, team: $team)
+}

--- a/slot/src/graphql/deployments/transfer.graphql
+++ b/slot/src/graphql/deployments/transfer.graphql
@@ -1,3 +1,3 @@
-mutation TransferDeployment($name: String!, $team: String!) {
-	transferDeployment(name: $name, team: $team)
+mutation TransferDeployment($name: String!, $service: DeploymentService!, $team: String!) {
+	transferDeployment(name: $name, service: $service, team: $team)
 }

--- a/slot/src/graphql/deployments/transfer.rs
+++ b/slot/src/graphql/deployments/transfer.rs
@@ -1,0 +1,9 @@
+use graphql_client::GraphQLQuery;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    response_derives = "Debug",
+    schema_path = "schema.json",
+    query_path = "src/graphql/deployments/transfer.graphql"
+)]
+pub struct TransferDeployment;

--- a/slot/src/graphql/team/create.graphql
+++ b/slot/src/graphql/team/create.graphql
@@ -1,5 +1,6 @@
 mutation CreateTeam($name: String!) {
 	createTeam(name: $name) {
 		id
+		name
 	}
 }

--- a/slot/src/graphql/team/create.graphql
+++ b/slot/src/graphql/team/create.graphql
@@ -1,0 +1,5 @@
+mutation CreateTeam($name: String!) {
+	createTeam(name: $name) {
+		id
+	}
+}

--- a/slot/src/graphql/team/mod.rs
+++ b/slot/src/graphql/team/mod.rs
@@ -4,6 +4,14 @@ use graphql_client::GraphQLQuery;
 #[graphql(
     response_derives = "Debug",
     schema_path = "schema.json",
+    query_path = "src/graphql/team/create.graphql"
+)]
+pub struct CreateTeam;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    response_derives = "Debug",
+    schema_path = "schema.json",
     query_path = "src/graphql/team/members.graphql"
 )]
 pub struct TeamMembersList;

--- a/slot/src/graphql/team/teams.graphql
+++ b/slot/src/graphql/team/teams.graphql
@@ -1,0 +1,19 @@
+query TeamMembersList($team: ID!) {
+  team(id: $team) {
+    members {
+      edges {
+        node {
+          id
+        }
+      }
+    }
+  }
+}
+
+mutation TeamMemberAdd($team: ID!, $accounts: [ID!]!) {
+  addToTeam(teamID: $team, userIDs: $accounts)
+}
+
+mutation TeamMemberRemove($team: ID!, $accounts: [ID!]!) {
+  removeFromTeam(teamID: $team, userIDs: $accounts)
+}


### PR DESCRIPTION
Introduces commands to create teams and transfer deployments between teams in the CLI. Adds respective GraphQL queries and updates schema to support new operations.