### PR TITLE
feat(teams): add command to list all teams

### DIFF
--- a/cli/src/command/mod.rs
+++ b/cli/src/command/mod.rs
@@ -22,6 +22,9 @@ pub enum Command {
 
     #[command(about = "Manage Slot team.", aliases = ["t"])]
     Teams(Teams),
+
+    #[command(about = "List all available teams.")]
+    List(teams::list::TeamListAllArgs),
 }
 
 impl Command {
@@ -30,6 +33,7 @@ impl Command {
             Command::Auth(cmd) => cmd.run().await,
             Command::Deployments(cmd) => cmd.run().await,
             Command::Teams(cmd) => cmd.run().await,
+            Command::List(cmd) => cmd.run().await,
         }
     }
 }

--- a/cli/src/command/teams/list.rs
+++ b/cli/src/command/teams/list.rs
@@ -1,0 +1,35 @@
+use anyhow::Result;
+use clap::Args;
+use slot::api::Client;
+use slot::credential::Credentials;
+use slot::graphql::team::{teams_list, TeamsList};
+use slot::graphql::GraphQLQuery;
+
+#[derive(Debug, Args, serde::Serialize)]
+#[command(next_help_heading = "List all teams")]
+pub struct TeamListAllArgs {}
+
+impl TeamListAllArgs {
+    pub async fn run(&self) -> Result<()> {
+        let request_body = TeamsList::build_query(teams_list::Variables {});
+
+        let user = Credentials::load()?;
+        let client = Client::new_with_token(user.access_token);
+
+        let data: teams_list::ResponseData = client.query(&request_body).await?;
+
+        data.me
+            .unwrap()
+            .teams
+            .edges
+            .into_iter()
+            .flatten()
+            .for_each(|edge| {
+                if let Some(node) = edge.and_then(|edge| edge.node) {
+                    println!("  {}", node.name)
+                }
+            });
+
+        Ok(())
+    }
+}

--- a/cli/src/command/teams/mod.rs
+++ b/cli/src/command/teams/mod.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use clap::{Args, Subcommand};
 
 mod create;
+pub(crate) mod list;
 mod members;
 
 #[derive(Debug, Args)]

--- a/slot/src/graphql/team/mod.rs
+++ b/slot/src/graphql/team/mod.rs
@@ -31,3 +31,11 @@ pub struct TeamMemberAdd;
     query_path = "src/graphql/team/members.graphql"
 )]
 pub struct TeamMemberRemove;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    response_derives = "Debug",
+    schema_path = "schema.json",
+    query_path = "src/graphql/team/teams.graphql"
+)]
+pub struct TeamsList;

--- a/slot/src/graphql/team/teams.graphql
+++ b/slot/src/graphql/team/teams.graphql
@@ -1,3 +1,17 @@
+query TeamsList {
+  me {
+    id
+    name
+    teams {
+      edges {
+        node {
+          name
+        }
+      }
+    }
+  }
+}
+
 query TeamMembersList($team: ID!) {
   team(id: $team) {
     members {


### PR DESCRIPTION
Introduced a new CLI command to list all available teams. Added supporting GraphQL query and data handling logic to fetch and display the team list.