### PR TITLE
fix(auth): add missing newline in team info output

### DIFF
--- a/cli/src/command/auth/info.rs
+++ b/cli/src/command/auth/info.rs
@@ -22,6 +22,7 @@ impl InfoArgs {
         let teams = res.me.unwrap().teams.edges.unwrap();
         for edge in teams {
             let team = edge.unwrap().node.unwrap();
+            println!();
             println!("  Name: {}", team.name);
 
             println!("  Deployments:");


### PR DESCRIPTION
Added a newline to improve readability when displaying team info.