### PR TITLE
fix(auth): update field name to username in account info

### DIFF
--- a/cli/src/command/auth/info.rs
+++ b/cli/src/command/auth/info.rs
@@ -41,8 +41,7 @@ impl InfoArgs {
                 let member = edge.unwrap().node.unwrap();
                 println!(
                     "    Member: {} ({:?})",
-                    member.account.name.unwrap(),
-                    member.role
+                    member.account.username, member.role
                 );
             }
         }

--- a/slot/src/graphql/auth/info.graphql
+++ b/slot/src/graphql/auth/info.graphql
@@ -14,7 +14,7 @@ query Me {
               node {
                 account {
                   id
-                  name
+                  username
                 }
                 role
               }


### PR DESCRIPTION
Updated GraphQL schema and CLI output to use `username` instead of `name` for account info to ensure consistency across displays.