### PR TITLE
fix(deployments): correct spacing in deployment output text

### DIFF
--- a/cli/src/command/deployments/create.rs
+++ b/cli/src/command/deployments/create.rs
@@ -110,7 +110,7 @@ impl CreateArgs {
         };
 
         println!(
-            "Deploying {}...",
+            "Deploying {} ...",
             super::service_url(&self.project, service)
         );
 


### PR DESCRIPTION
This makes the URL clickable without breaking.