### PR TITLE
fix(deployments): improve deprecated warning formatting

### DIFF
--- a/cli/src/command/deployments/describe.rs
+++ b/cli/src/command/deployments/describe.rs
@@ -41,8 +41,11 @@ impl DescribeArgs {
             println!("Version: {}", deployment.version);
 
             if deployment.deprecated.unwrap_or(false) {
+                println!();
+                println!("NOTE:");
                 println!("This deployment is deprecated and immutable.");
                 println!("Please delete it and re-create. Note that this will reset the storage.");
+                println!();
             }
 
             println!(


### PR DESCRIPTION
Added additional spacing and a "NOTE:" label to improve the clarity of the deprecation message in deployment descriptions.