### PR TITLE
ci: add env variable to Windows workflow configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
       - uses: actions-rust-lang/rustfmt@v1
 
   ensure-windows:
+    env:
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5"
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Added CMAKE_POLICY_VERSION_MINIMUM to ensure-windows job in CI.