### PR TITLE
feat(deployments): add team support for deployments

### DIFF
--- a/cli/src/command/deployments/create.rs
+++ b/cli/src/command/deployments/create.rs
@@ -20,6 +20,10 @@ pub struct CreateArgs {
     #[arg(help = "The name of the project.")]
     pub project: String,
 
+    #[arg(long, short, value_name = "team")]
+    #[arg(help = "The name of the team. Defaults to a team named after your username.")]
+    pub team: Option<String>,
+
     #[arg(short, long, default_value = "basic")]
     #[arg(value_name = "tier")]
     #[arg(help = "Deployment tier.")]
@@ -103,6 +107,7 @@ impl CreateArgs {
             service,
             wait: Some(true),
             regions: self.regions.clone(),
+            team: self.team.clone(),
         });
 
         let user = Credentials::load()?;

--- a/cli/src/command/deployments/create.rs
+++ b/cli/src/command/deployments/create.rs
@@ -20,7 +20,7 @@ pub struct CreateArgs {
     #[arg(help = "The name of the project.")]
     pub project: String,
 
-    #[arg(long, short, value_name = "team")]
+    #[arg(long, value_name = "team")]
     #[arg(help = "The name of the team. Defaults to a team named after your username.")]
     pub team: Option<String>,
 

--- a/slot/src/graphql/deployments/create.graphql
+++ b/slot/src/graphql/deployments/create.graphql
@@ -4,6 +4,7 @@ mutation CreateDeployment(
 	$tier: DeploymentTier!
 	$wait: Boolean
 	$regions: [String!]
+	$team: String
 ) {
 	createDeployment(
 		name: $project
@@ -11,6 +12,7 @@ mutation CreateDeployment(
 		tier: $tier
 		wait: $wait
 		regions: $regions
+		team: $team
 	) {
 		__typename
 		id


### PR DESCRIPTION
Added optional team parameter to deployment creation command and GraphQL schema, allowing users to specify a team for deployments. Defaults to the username-based team if not provided.