### PR TITLE
ci: update e2e workflow to include cron scheduling

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,10 @@
 name: e2e
 
-on: pull_request
+on:
+  pull_request:
+  schedule:
+    - cron: '0 8 * * *'
+    - cron: '0 14 * * *'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Added two scheduled runs at 8 AM and 2 PM daily for the e2e workflow.