### PR TITLE
fix(slot): use name in team related queries

### DIFF
--- a/slot/schema.json
+++ b/slot/schema.json
@@ -15422,7 +15422,7 @@
                 {
                   "defaultValue": null,
                   "description": null,
-                  "name": "teamID",
+                  "name": "name",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -15475,7 +15475,7 @@
                 {
                   "defaultValue": null,
                   "description": null,
-                  "name": "teamID",
+                  "name": "name",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -19296,13 +19296,13 @@
                 {
                   "defaultValue": null,
                   "description": null,
-                  "name": "id",
+                  "name": "name",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
                     "ofType": {
                       "kind": "SCALAR",
-                      "name": "ID",
+                      "name": "String",
                       "ofType": null
                     }
                   }

--- a/slot/src/graphql/team/teams.graphql
+++ b/slot/src/graphql/team/teams.graphql
@@ -1,5 +1,5 @@
-query TeamMembersList($team: ID!) {
-  team(id: $team) {
+query TeamMembersList($team: String!) {
+  team(name: $team) {
     members {
       edges {
         node {
@@ -11,9 +11,9 @@ query TeamMembersList($team: ID!) {
 }
 
 mutation TeamMemberAdd($team: ID!, $accounts: [ID!]!) {
-  addToTeam(teamID: $team, userIDs: $accounts)
+  addToTeam(name: $team, userIDs: $accounts)
 }
 
 mutation TeamMemberRemove($team: ID!, $accounts: [ID!]!) {
-  removeFromTeam(teamID: $team, userIDs: $accounts)
+  removeFromTeam(name: $team, userIDs: $accounts)
 }


### PR DESCRIPTION
Updated fields in schema and GraphQL queries to use 'name' instead
of 'teamID', ensuring consistency and aligning with the expected
data structure.