### PR TITLE
fix(slot): rename userIDs to usernames in schema

### DIFF
--- a/slot/schema.json
+++ b/slot/schema.json
@@ -15436,7 +15436,7 @@
                 {
                   "defaultValue": null,
                   "description": null,
-                  "name": "userIDs",
+                  "name": "usernames",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -15448,7 +15448,7 @@
                         "name": null,
                         "ofType": {
                           "kind": "SCALAR",
-                          "name": "ID",
+                          "name": "String",
                           "ofType": null
                         }
                       }
@@ -15489,7 +15489,7 @@
                 {
                   "defaultValue": null,
                   "description": null,
-                  "name": "userIDs",
+                  "name": "usernames",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -15501,7 +15501,7 @@
                         "name": null,
                         "ofType": {
                           "kind": "SCALAR",
-                          "name": "ID",
+                          "name": "String",
                           "ofType": null
                         }
                       }

--- a/slot/src/graphql/team/teams.graphql
+++ b/slot/src/graphql/team/teams.graphql
@@ -10,10 +10,10 @@ query TeamMembersList($team: String!) {
   }
 }
 
-mutation TeamMemberAdd($team: ID!, $accounts: [ID!]!) {
-  addToTeam(name: $team, userIDs: $accounts)
+mutation TeamMemberAdd($team: ID!, $accounts: [String!]!) {
+  addToTeam(name: $team, usernames: $accounts)
 }
 
-mutation TeamMemberRemove($team: ID!, $accounts: [ID!]!) {
-  removeFromTeam(name: $team, userIDs: $accounts)
+mutation TeamMemberRemove($team: ID!, $accounts: [String!]!) {
+  removeFromTeam(name: $team, usernames: $accounts)
 }


### PR DESCRIPTION
Updated schema and GraphQL queries to replace 'userIDs' with 'usernames' and change type from 'ID' to 'String' for consistency.