### PR TITLE
feat(version): centralize checks & notify on API error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7507,6 +7507,7 @@ checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http 1.3.0",
@@ -8500,6 +8501,7 @@ dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
  "cainome-cairo-serde 0.2.0",
+ "colored 2.2.0",
  "dirs 5.0.1",
  "graphql_client",
  "hyper 1.6.0",
@@ -8513,6 +8515,7 @@ dependencies = [
  "tokio",
  "tower-http 0.5.2",
  "tracing",
+ "update-informer",
  "url",
  "urlencoding",
  "webbrowser",
@@ -8541,7 +8544,6 @@ dependencies = [
  "tokio",
  "toml 0.8.20",
  "torii-cli",
- "update-informer",
  "url",
 ]
 
@@ -10182,6 +10184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53813bf5d5f0d8430794f8cc48e99521cc9e298066958d16383ccb8b39d182a7"
 dependencies = [
  "etcetera",
+ "reqwest 0.12.12",
  "semver 1.0.26",
  "serde",
  "serde_json",
@@ -10198,9 +10201,12 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
+ "rustls 0.23.23",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "url",
+ "webpki-roots 0.26.8",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,10 +33,6 @@ slot.workspace = true
 starknet.workspace = true
 toml = "0.8"
 url.workspace = true
-update-informer = { version = "1.1", default-features = false, features = [
-	"ureq",
-	"github",
-] }
 
 [[bin]]
 name = "slot"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,8 +4,7 @@ mod command;
 
 use crate::command::Command;
 use clap::Parser;
-use colored::*;
-use update_informer::{registry, Check};
+use slot::version;
 
 /// Slot CLI for Cartridge
 #[derive(Parser, Debug)]
@@ -20,11 +19,6 @@ async fn main() {
     env_logger::init();
     let cli = Cli::parse();
 
-    let name = "cartridge-gg/slot";
-    let current = env!("CARGO_PKG_VERSION");
-    let informer = update_informer::new(registry::GitHub, name, current)
-        .interval(std::time::Duration::from_secs(60 * 60));
-
     match &cli.command.run().await {
         Ok(_) => {}
         Err(e) => {
@@ -33,19 +27,6 @@ async fn main() {
         }
     }
 
-    if let Some(version) = informer.check_version().ok().flatten() {
-        notify_new_version(current, version.to_string().as_str());
-    }
-}
-
-fn notify_new_version(current_version: &str, latest_version: &str) {
-    println!(
-        "\n{} {}{} → {}",
-        "Slot CLI update available:".bold(),
-        "v".red().bold(),
-        current_version.red().bold(),
-        latest_version.green().bold()
-    );
-    println!("To upgrade, run: {}", "`slotup`".cyan().bold());
-    println!("\n")
+    // Check for new version after command execution
+    version::check_for_new_version();
 }

--- a/slot/Cargo.toml
+++ b/slot/Cargo.toml
@@ -27,11 +27,12 @@ starknet.workspace = true
 url.workspace = true
 tempfile = "3.10.1"
 hyper.workspace = true
-
 # https://github.com/cartridge-gg/controller/pull/1549
 account_sdk = { git = "https://github.com/cartridge-gg/controller", rev = "05fe96f4" }
 base64 = "0.22.1"
+colored = "2.0.0"
 num-bigint = "0.4.6"
+update-informer = { version = "1.1", default-features = false, features = ["ureq", "github", "rustls-tls"] }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/slot/src/lib.rs
+++ b/slot/src/lib.rs
@@ -10,6 +10,7 @@ pub mod read;
 pub mod server;
 pub mod session;
 pub mod vars;
+pub mod version;
 
 pub(crate) mod error;
 pub(crate) mod utils;

--- a/slot/src/version.rs
+++ b/slot/src/version.rs
@@ -1,0 +1,38 @@
+use colored::*;
+use update_informer::{registry, Check};
+
+/// Checks if a new version of the slot CLI is available and notifies the user
+pub fn check_for_new_version() {
+    let name = "cartridge-gg/slot";
+    let current = env!("CARGO_PKG_VERSION");
+
+    let informer = update_informer::new(registry::GitHub, name, current)
+        .interval(std::time::Duration::from_secs(60 * 100));
+
+    let check_result = informer.check_version();
+
+    if check_result.is_err() {
+        println!("error checking for new version");
+    }
+
+    if let Some(version) = check_result.ok().flatten() {
+        notify_new_version(current, version.to_string().as_str());
+    }
+}
+
+/// Prints a notification about a new version being available
+pub fn notify_new_version(current_version: &str, latest_version: &str) {
+    let message = format!(
+        "\n{} {}{} → {}",
+        "Slot CLI update available:".bold(),
+        "v".red().bold(),
+        current_version.red().bold(),
+        latest_version.green().bold()
+    );
+
+    let upgrade_message = format!("To upgrade, run: {}", "`slotup`".cyan().bold());
+
+    println!("{}", message);
+    println!("{}", upgrade_message);
+    println!("\n");
+}


### PR DESCRIPTION
Refactored version update logic into a dedicated module `slot::version`. Integrated update checks into CLI and API error handling for consistency. Updated dependencies for `colored` and `update-informer`.