### PR TITLE
fix(auth): correct balance calculations in transfer output

### DIFF
--- a/cli/src/command/auth/transfer.rs
+++ b/cli/src/command/auth/transfer.rs
@@ -59,14 +59,14 @@ impl TransferArgs {
             res.transfer.account_before,
             res.transfer.account_before / 100,
             res.transfer.account_after,
-            res.transfer.account_before / 100
+            res.transfer.account_after / 100
         );
         println!(
             "Team balance: {} credits (~${} USD) -> {} credits (~${} USD)",
             res.transfer.team_before,
             res.transfer.team_before / 100,
             res.transfer.team_after,
-            res.transfer.team_before / 100
+            res.transfer.team_after / 100
         );
 
         Ok(())


### PR DESCRIPTION
Corrected the displayed USD conversion values in transfer output to use updated balances instead of previous balances.