### PR TITLE
feat(auth): add creditsPlain field to user info

### DIFF
--- a/cli/src/command/auth/info.rs
+++ b/cli/src/command/auth/info.rs
@@ -15,11 +15,22 @@ impl InfoArgs {
 
         let request_body = Me::build_query(Variables {});
         let res: ResponseData = client.query(&request_body).await?;
-        println!("Username: {}", res.me.clone().unwrap().username);
+        let info = res.me.clone().unwrap();
+        println!("Username: {}", info.username);
+        println!(
+            "Credits: {} (${})",
+            info.credits_plain,
+            info.credits_plain / 100
+        );
 
         println!();
         println!("Teams:");
         let teams = res.me.unwrap().teams.edges.unwrap();
+
+        if teams.is_empty() {
+            println!("  No teams yet");
+        }
+
         for edge in teams {
             let team = edge.unwrap().node.unwrap();
             println!();
@@ -27,6 +38,11 @@ impl InfoArgs {
 
             println!("  Deployments:");
             let deployments = team.deployments.edges.unwrap();
+
+            if deployments.is_empty() {
+                println!("    No deployments yet");
+            }
+
             for edge in deployments {
                 let deployment = edge.unwrap().node.unwrap();
                 println!(

--- a/slot/schema.json
+++ b/slot/schema.json
@@ -763,6 +763,22 @@
                   "ofType": null
                 }
               }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "creditsPlain",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
             }
           ],
           "inputFields": [],

--- a/slot/src/graphql/auth/info.graphql
+++ b/slot/src/graphql/auth/info.graphql
@@ -2,6 +2,7 @@ query Me {
   me {
     id
     username
+    creditsPlain
 
     teams {
       edges {

--- a/slot/src/graphql/auth/mod.rs
+++ b/slot/src/graphql/auth/mod.rs
@@ -96,6 +96,7 @@ mod tests {
             teams: me::MeMeTeams {
                 edges: Some(vec![]),
             },
+            credits_plain: 0,
         };
 
         let account = AccountInfo::from(me);


### PR DESCRIPTION
Added creditsPlain field to GraphQL schema and updated CLI to display user credits in both integer and dollar formats. Improved output for empty teams and deployments.