### PR TITLE
fix(slot): enable serde support for num-bigint dependency

### DIFF
--- a/slot/Cargo.toml
+++ b/slot/Cargo.toml
@@ -31,7 +31,7 @@ hyper.workspace = true
 account_sdk = { git = "https://github.com/cartridge-gg/controller", rev = "05fe96f4" }
 base64 = "0.22.1"
 colored = "2.0.0"
-num-bigint = "0.4.6"
+num-bigint = { version = "0.4.6", features = [ "serde" ] }
 update-informer = { version = "1.1", default-features = false, features = ["ureq", "github", "rustls-tls"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Added the "serde" feature to the num-bigint crate to ensure proper serialization and deserialization support.