### PR TITLE
feat(cli): add auto-update functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8502,6 +8502,7 @@ dependencies = [
  "base64 0.22.1",
  "cainome-cairo-serde 0.2.0",
  "colored 2.2.0",
+ "dialoguer",
  "dirs 5.0.1",
  "graphql_client",
  "hyper 1.6.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,7 +1639,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.100",
- "which",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -8519,6 +8519,7 @@ dependencies = [
  "url",
  "urlencoding",
  "webbrowser",
+ "which 5.0.0",
 ]
 
 [[package]]
@@ -10593,6 +10594,19 @@ dependencies = [
  "home",
  "once_cell",
  "rustix 0.38.44",
+]
+
+[[package]]
+name = "which"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bf3ea8596f3a0dd5980b46430f2058dfe2c36a27ccfbb1845d6fbfcd9ba6e14"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -60,3 +60,14 @@ slot teams <Team Name> list
 slot teams <Team Name> add <Account Name>
 slot teams <Team Name> remove <Account Name>
 ```
+
+## Environment Variables
+
+Slot CLI supports the following environment variables to control its behavior:
+
+| Variable | Description |
+|----------|-------------|
+| `SLOT_DISABLE_AUTO_UPDATE` | When set, disables automatic updates. The CLI will still check for updates and notify you, but won't attempt to update automatically. |
+| `SLOT_FORCE_AUTO_UPDATE` | When set, forces automatic updates without asking for confirmation. Useful for CI/CD environments. |
+| `CARTRIDGE_API_URL` | Override the default Cartridge API URL. |
+| `CARTRIDGE_KEYCHAIN_URL` | Override the default Cartridge Keychain URL. |

--- a/cli/src/command/mod.rs
+++ b/cli/src/command/mod.rs
@@ -4,6 +4,7 @@ pub mod teams;
 
 use anyhow::Result;
 use clap::Subcommand;
+use slot::version;
 
 use auth::Auth;
 use deployments::Deployments;
@@ -26,6 +27,10 @@ pub enum Command {
 
 impl Command {
     pub async fn run(&self) -> Result<()> {
+        // Check for new version and run auto-update if available
+        version::check_and_auto_update();
+
+        // Run the actual command
         match &self {
             Command::Auth(cmd) => cmd.run().await,
             Command::Deployments(cmd) => cmd.run().await,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,7 +4,6 @@ mod command;
 
 use crate::command::Command;
 use clap::Parser;
-use slot::version;
 
 /// Slot CLI for Cartridge
 #[derive(Parser, Debug)]
@@ -26,7 +25,4 @@ async fn main() {
             std::process::exit(1);
         }
     }
-
-    // Check for new version after command execution
-    version::check_for_new_version();
 }

--- a/slot/Cargo.toml
+++ b/slot/Cargo.toml
@@ -34,6 +34,7 @@ colored = "2.0.0"
 num-bigint = { version = "0.4.6", features = [ "serde" ] }
 update-informer = { version = "1.1", default-features = false, features = ["ureq", "github", "rustls-tls"] }
 which = "5.0.0"
+dialoguer = "0.11.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/slot/Cargo.toml
+++ b/slot/Cargo.toml
@@ -33,6 +33,7 @@ base64 = "0.22.1"
 colored = "2.0.0"
 num-bigint = { version = "0.4.6", features = [ "serde" ] }
 update-informer = { version = "1.1", default-features = false, features = ["ureq", "github", "rustls-tls"] }
+which = "5.0.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/slot/src/api.rs
+++ b/slot/src/api.rs
@@ -6,7 +6,6 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use url::Url;
 
 use crate::error::Error;
-use crate::version;
 use crate::{credential::AccessToken, vars};
 
 #[derive(Debug)]
@@ -54,7 +53,6 @@ impl Client {
             .await;
 
         if response.is_err() {
-            version::check_for_new_version();
             return Err(Error::ReqwestError(response.err().unwrap()));
         }
 
@@ -65,7 +63,6 @@ impl Client {
         }
 
         if !res.status().is_success() {
-            version::check_for_new_version();
             return Err(anyhow::anyhow!("API error: {}", res.status()).into());
         }
 

--- a/slot/src/version.rs
+++ b/slot/src/version.rs
@@ -1,4 +1,6 @@
 use colored::*;
+use dialoguer::theme::ColorfulTheme;
+use dialoguer::Confirm;
 use std::env;
 use std::process::{exit, Command};
 use update_informer::{registry, Check};
@@ -157,7 +159,7 @@ pub fn check_and_auto_update() -> bool {
             return run_auto_update();
         }
 
-        // Otherwise, prompt for confirmation
+        // Otherwise, prompt for confirmation using dialoguer
         println!(
             "\n{} {}{} → {}",
             "Slot CLI update available:".bold(),
@@ -166,16 +168,17 @@ pub fn check_and_auto_update() -> bool {
             version.green().bold()
         );
 
-        print!("Do you want to update now (recommended)? [y/N] ");
-        std::io::Write::flush(&mut std::io::stdout()).unwrap();
+        let confirmation = Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt("Do you want to update now (recommended)?")
+            .default(true)
+            .show_default(true)
+            .wait_for_newline(true)
+            .interact()
+            .unwrap_or(false);
 
-        let mut input = String::new();
-        if std::io::stdin().read_line(&mut input).is_ok() {
-            let input = input.trim().to_lowercase();
-            if input == "y" || input == "yes" {
-                println!("Updating Slot CLI first...");
-                return run_auto_update();
-            }
+        if confirmation {
+            println!("Updating Slot CLI first...");
+            return run_auto_update();
         }
 
         // User declined the update, just show the notification

--- a/slot/src/version.rs
+++ b/slot/src/version.rs
@@ -121,9 +121,9 @@ pub fn re_execute_current_command() {
 /// Returns true if an update was performed
 pub fn check_and_auto_update() -> bool {
     // Skip auto-update if disabled or running via cargo
-    // if is_running_via_cargo_run() {
-    //     return false;
-    // }
+    if is_running_via_cargo_run() {
+        return false;
+    }
 
     if is_auto_update_disabled() {
         // Still check for updates to notify the user, but don't auto-update

--- a/slotup/slotup
+++ b/slotup/slotup
@@ -76,7 +76,7 @@ main() {
   if [[ "$SLOTUP_REPO" == "cartridge-gg/slot" && -z "$SLOTUP_BRANCH" && -z "$SLOTUP_COMMIT" ]]; then
     SLOTUP_VERSION=${SLOTUP_VERSION-stable}
     SLOTUP_TAG=$SLOTUP_VERSION
-    
+
     # Normalize versions (handle channels, versions without v prefix
     if [[ "$SLOTUP_VERSION" == "stable" ]]; then
       # Fetch the list of releases from the GitHub API and filter out `prerelease`` releases and `alpha`` releases
@@ -272,23 +272,23 @@ download() {
   fi
 }
 
-# Banner Function for Slot 
+# Banner Function for Slot
 banner() {
   printf '
 
 ═════════════════════════════════════════════════════════════════════════
- 
+
 
 
                   ███████╗██╗      ██████╗ ████████╗
                   ██╔════╝██║     ██╔═══██╗╚══██╔══╝
-                  ███████╗██║     ██║   ██║   ██║   
-                  ╚════██║██║     ██║   ██║   ██║   
-                  ███████║███████╗╚██████╔╝   ██║   
-                  ╚══════╝╚══════╝ ╚═════╝    ╚═╝   
+                  ███████╗██║     ██║   ██║   ██║
+                  ╚════██║██║     ██║   ██║   ██║
+                  ███████║███████╗╚██████╔╝   ██║
+                  ╚══════╝╚══════╝ ╚═════╝    ╚═╝
 
 
-              Repo : https://github.com/cartridge-gg/slot            
+              Repo : https://github.com/cartridge-gg/slot
 
 ═════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
Introduced auto-update support for the CLI using `slotup`. Checks for a new version and triggers an update if applicable. Added environment variable control and binary checks for flexibility.