### PR TITLE
feat(slotup): add version check to skip reinstall

### DIFF
--- a/slotup/slotup
+++ b/slotup/slotup
@@ -76,7 +76,7 @@ main() {
   if [[ "$SLOTUP_REPO" == "cartridge-gg/slot" && -z "$SLOTUP_BRANCH" && -z "$SLOTUP_COMMIT" ]]; then
     SLOTUP_VERSION=${SLOTUP_VERSION-stable}
     SLOTUP_TAG=$SLOTUP_VERSION
-    
+
     # Normalize versions (handle channels, versions without v prefix
     if [[ "$SLOTUP_VERSION" == "stable" ]]; then
       # Fetch the list of releases from the GitHub API and filter out `prerelease`` releases and `alpha`` releases
@@ -95,6 +95,19 @@ main() {
       SLOTUP_VERSION="v${SLOTUP_VERSION}"
       SLOTUP_TAG="${SLOTUP_VERSION}"
     fi
+
+    # Check if slot is installed and has the latest version
+    CURRENT_SLOT="$SLOT_BIN_DIR/slot"
+    if [ -x "$CURRENT_SLOT" ] && [ "$SLOTUP_VERSION" != "nightly" ]; then
+      # Get installed version (remove "v" prefix for consistent comparison)
+      INSTALLED_VERSION="$($CURRENT_SLOT --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
+      LATEST_VERSION="$(echo "$SLOTUP_TAG" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
+      if [ "$INSTALLED_VERSION" = "$LATEST_VERSION" ]; then
+        say "slot version $INSTALLED_VERSION is already the latest. Skipping installation."
+        exit 0
+      fi
+    fi
+
 
     say "installing slot (version ${SLOTUP_VERSION}, tag ${SLOTUP_TAG})"
 
@@ -272,23 +285,23 @@ download() {
   fi
 }
 
-# Banner Function for Slot 
+# Banner Function for Slot
 banner() {
   printf '
 
 ═════════════════════════════════════════════════════════════════════════
- 
+
 
 
                   ███████╗██╗      ██████╗ ████████╗
                   ██╔════╝██║     ██╔═══██╗╚══██╔══╝
-                  ███████╗██║     ██║   ██║   ██║   
-                  ╚════██║██║     ██║   ██║   ██║   
-                  ███████║███████╗╚██████╔╝   ██║   
-                  ╚══════╝╚══════╝ ╚═════╝    ╚═╝   
+                  ███████╗██║     ██║   ██║   ██║
+                  ╚════██║██║     ██║   ██║   ██║
+                  ███████║███████╗╚██████╔╝   ██║
+                  ╚══════╝╚══════╝ ╚═════╝    ╚═╝
 
 
-              Repo : https://github.com/cartridge-gg/slot            
+              Repo : https://github.com/cartridge-gg/slot
 
 ═════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
Added a mechanism to verify if the installed version of `slot` matches the latest version, skipping reinstallation when current and latest versions align.