### PR TITLE
feat(teams): add invoices subcommand to list team invoices

### DIFF
--- a/cli/src/command/teams/invoices.rs
+++ b/cli/src/command/teams/invoices.rs
@@ -1,0 +1,100 @@
+use anyhow::Result;
+use chrono::prelude::*;
+use clap::Args;
+use slot::api::Client;
+use slot::credential::Credentials;
+use slot::graphql::team::team_invoices::{InvoiceOrder, Variables};
+use slot::graphql::team::team_invoices::{InvoiceOrderField, OrderDirection};
+use slot::graphql::team::TeamInvoices;
+use slot::graphql::GraphQLQuery;
+
+#[derive(Debug, Args)]
+pub struct InvoicesArgs {}
+
+impl InvoicesArgs {
+    pub async fn run(&self, team_name: String) -> Result<()> {
+        let request_body = TeamInvoices::build_query(Variables {
+            team: team_name.clone(),
+            first: Some(100), // Get up to 100 invoices
+            after: None,
+            order_by: Some(InvoiceOrder {
+                field: InvoiceOrderField::CREATED_AT,
+                direction: OrderDirection::DESC, // Most recent first
+            }),
+        });
+
+        let user = Credentials::load()?;
+        let client = Client::new_with_token(user.access_token);
+
+        let data: slot::graphql::team::team_invoices::ResponseData =
+            client.query(&request_body).await?;
+        let team = data
+            .team
+            .ok_or_else(|| anyhow::anyhow!("Team '{}' not found", team_name))?;
+
+        let edges = team.invoices.edges.unwrap_or_default();
+
+        if edges.is_empty() {
+            println!("No invoices found for team '{}'", team_name);
+            return Ok(());
+        }
+
+        let current_month = Utc::now().format("%Y-%m").to_string();
+
+        println!("Invoices for team '{}':", team_name);
+        println!("=====================================");
+
+        for edge in edges.into_iter().flatten() {
+            if let Some(node) = edge.node {
+                let is_current_month = node.month == current_month;
+                let prefix = if is_current_month { ">>> " } else { "    " };
+
+                println!("{}Month: {}", prefix, node.month);
+                println!(
+                    "{}Total Credits: {}",
+                    prefix,
+                    format_credits(node.total_credits)
+                );
+                println!(
+                    "{}Total Debits: {}",
+                    prefix,
+                    format_credits(node.total_debits)
+                );
+                println!(
+                    "{}Slot Debits: {}",
+                    prefix,
+                    format_credits(node.slot_debits)
+                );
+                println!(
+                    "{}Paymaster Debits: {}",
+                    prefix,
+                    format_credits(node.paymaster_debits)
+                );
+                println!(
+                    "{}Incubator Credits: {}",
+                    prefix,
+                    format_credits(node.incubator_credits)
+                );
+                println!("{}Net Amount: {}", prefix, format_credits(node.net_amount));
+                println!(
+                    "{}Incubator Stage: {}",
+                    prefix,
+                    node.incubator_stage.unwrap_or_else(|| "None".to_string())
+                );
+                println!(
+                    "{}Finalized: {}",
+                    prefix,
+                    if node.finalized { "Yes" } else { "No" }
+                );
+                println!("{}---\n\n", prefix);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn format_credits(credits: i64) -> String {
+    let dollars = credits as f64 / 100.0;
+    format!("${:.2}", dollars)
+}

--- a/cli/src/command/teams/invoices.rs
+++ b/cli/src/command/teams/invoices.rs
@@ -61,27 +61,27 @@ impl InvoicesArgs {
 
                 table.add_row(vec![Cell::new("Month"), Cell::new(&node.month)]);
                 table.add_row(vec![
-                    Cell::new("Total Credits"),
+                    Cell::new("Total Credits (top up + reimbursement)"),
                     Cell::new(format_credits(node.total_credits)),
                 ]);
                 table.add_row(vec![
-                    Cell::new("Total Debits"),
-                    Cell::new(format_credits(node.total_debits)),
-                ]);
-                table.add_row(vec![
-                    Cell::new("Slot Debits"),
-                    Cell::new(format_credits(node.slot_debits)),
-                ]);
-                table.add_row(vec![
-                    Cell::new("Paymaster Debits"),
-                    Cell::new(format_credits(node.paymaster_debits)),
-                ]);
-                table.add_row(vec![
-                    Cell::new("Incubator Credits"),
+                    Cell::new(" -> Incubator Credits"),
                     Cell::new(format_credits(node.incubator_credits)),
                 ]);
                 table.add_row(vec![
-                    Cell::new("Net Amount"),
+                    Cell::new("Debits (slot + paymaster)"),
+                    Cell::new(format_credits(node.total_debits)),
+                ]);
+                table.add_row(vec![
+                    Cell::new(" -> Slot Debits"),
+                    Cell::new(format_credits(node.slot_debits)),
+                ]);
+                table.add_row(vec![
+                    Cell::new(" -> Paymaster Debits"),
+                    Cell::new(format_credits(node.paymaster_debits)),
+                ]);
+                table.add_row(vec![
+                    Cell::new("Net Amount Paid"),
                     Cell::new(format_credits(node.net_amount)),
                 ]);
                 table.add_row(vec![

--- a/cli/src/command/teams/mod.rs
+++ b/cli/src/command/teams/mod.rs
@@ -1,12 +1,14 @@
 use self::members::{TeamAddArgs, TeamListArgs, TeamRemoveArgs};
 use crate::command::teams::create::CreateTeamArgs;
 use crate::command::teams::delete::DeleteTeamArgs;
+use crate::command::teams::invoices::InvoicesArgs;
 use crate::command::teams::update::UpdateTeamArgs;
 use anyhow::Result;
 use clap::{Args, Subcommand};
 
 mod create;
 mod delete;
+mod invoices;
 mod members;
 mod update;
 
@@ -38,6 +40,9 @@ pub enum TeamsCommands {
 
     #[command(about = "Remove a team member.")]
     Remove(TeamRemoveArgs),
+
+    #[command(about = "List team invoices.")]
+    Invoices(InvoicesArgs),
 }
 
 impl Teams {
@@ -49,6 +54,7 @@ impl Teams {
             TeamsCommands::Create(args) => args.run(self.name.clone()).await,
             TeamsCommands::Update(args) => args.run(self.name.clone()).await,
             TeamsCommands::Delete(args) => args.run(self.name.clone()).await,
+            TeamsCommands::Invoices(args) => args.run(self.name.clone()).await,
         }
     }
 }

--- a/slot/src/graphql/team/invoices.graphql
+++ b/slot/src/graphql/team/invoices.graphql
@@ -1,0 +1,33 @@
+query TeamInvoices($team: String!, $first: Int, $after: Cursor, $orderBy: InvoiceOrder) {
+  team(name: $team) {
+    id
+    name
+    invoices(first: $first, after: $after, orderBy: $orderBy) {
+      edges {
+        node {
+          id
+          teamID
+          month
+          totalCredits
+          totalDebits
+          slotDebits
+          paymasterDebits
+          incubatorCredits
+          netAmount
+          incubatorStage
+          createdAt
+          updatedAt
+          finalized
+        }
+        cursor
+      }
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+    }
+  }
+}

--- a/slot/src/graphql/team/mod.rs
+++ b/slot/src/graphql/team/mod.rs
@@ -1,5 +1,8 @@
 use graphql_client::GraphQLQuery;
 
+pub type Cursor = String;
+pub type Time = String;
+
 #[derive(GraphQLQuery)]
 #[graphql(
     response_derives = "Debug",
@@ -46,3 +49,11 @@ pub struct TeamMemberRemove;
     query_path = "src/graphql/team/delete.graphql"
 )]
 pub struct DeleteTeam;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    response_derives = "Debug",
+    schema_path = "schema.json",
+    query_path = "src/graphql/team/invoices.graphql"
+)]
+pub struct TeamInvoices;


### PR DESCRIPTION
Introduced a new `Invoices` subcommand under teams to fetch and display team invoices. Supports listing up to 100 invoices, ordering by creation date in descending order, and formatting monetary values. Added new GraphQL query `TeamInvoices` for fetching invoices data.