### PR TITLE
dev: bump starknet-rs to 0.15.1 and use controller-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,20 +5,23 @@ version = 3
 [[package]]
 name = "account_sdk"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/controller?rev=05fe96f4#05fe96f46a81e45e98085b0d0bb263561c8af2a3"
+source = "git+https://github.com/cartridge-gg/controller-rs?rev=660ead4#660ead4db4cd9ce6ebcdaed3ab9edb0466911676"
 dependencies = [
  "alloy-primitives",
  "alloy-signer 0.12.6",
  "anyhow",
  "async-trait",
  "auto_impl",
- "cainome 0.6.0",
- "cainome-cairo-serde 0.2.0",
+ "cainome 0.8.0",
+ "cainome-cairo-serde 0.2.1",
  "chrono",
+ "ecdsa",
  "futures",
+ "graphql_client",
  "hex",
  "indexmap 2.8.0",
  "js-sys",
+ "k256",
  "lazy_static",
  "num-traits",
  "once_cell",
@@ -29,8 +32,8 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "serde_with",
- "starknet 0.14.0",
- "starknet-crypto 0.7.4",
+ "starknet 0.15.1",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "starknet-types-core",
  "thiserror 1.0.69",
  "tokio",
@@ -69,7 +72,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "starknet 0.13.0",
- "starknet-crypto 0.7.4",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "starknet-types-core",
  "thiserror 1.0.69",
  "tokio",
@@ -319,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.22"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c66bb6715b7499ea755bde4c96223ae8eb74e05c014ab38b9db602879ffb825"
+checksum = "8c77490fe91a0ce933a1f219029521f20fc28c2c0ca95d53fa4da9c00b8d9d4e"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -371,8 +374,8 @@ dependencies = [
  "futures",
  "futures-utils-wasm",
  "lru",
- "pin-project",
- "reqwest 0.12.12",
+ "pin-project 1.1.10",
+ "reqwest 0.12.15",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -414,8 +417,8 @@ dependencies = [
  "alloy-transport",
  "alloy-transport-http",
  "futures",
- "pin-project",
- "reqwest 0.12.12",
+ "pin-project 1.1.10",
+ "reqwest 0.12.15",
  "serde",
  "serde_json",
  "tokio",
@@ -584,7 +587,7 @@ checksum = "b367dcccada5b28987c2296717ee04b9a5637aacd78eacb1726ef211678b5212"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "reqwest 0.12.12",
+ "reqwest 0.12.15",
  "serde_json",
  "tower 0.5.2",
  "tracing",
@@ -1280,7 +1283,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-lite 2.6.0",
- "gloo-timers",
+ "gloo-timers 0.3.0",
  "kv-log-macro",
  "log",
  "memchr",
@@ -1394,7 +1397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "bytes",
  "futures-util",
  "http 1.3.0",
@@ -1403,7 +1406,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -1419,6 +1422,32 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
+dependencies = [
+ "axum-core 0.5.2",
+ "bytes",
+ "futures-util",
+ "http 1.3.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 1.0.2",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1443,13 +1472,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.3.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backon"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49fef586913a57ff189f25c9b3d034356a5bf6b3fa9a7f067588fe1698ba1f5d"
 dependencies = [
  "fastrand 2.3.0",
- "gloo-timers",
+ "gloo-timers 0.3.0",
  "tokio",
 ]
 
@@ -1497,6 +1545,18 @@ name = "base64ct"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb97d56060ee67d285efb8001fec9d2a4c710c32efd2e14b5cbb5ba71930fc2d"
+
+[[package]]
+name = "bigdecimal"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6773ddc0eafc0e509fb60e48dff7f450f8e674a0686ae8605e8d9901bd5eefa"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
 
 [[package]]
 name = "bincode"
@@ -1883,7 +1943,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "cainome-cairo-serde 0.1.0",
- "cainome-cairo-serde-derive",
+ "cainome-cairo-serde-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cainome-parser 0.1.1",
  "cainome-rs 0.1.0",
  "cainome-rs-macro 0.1.0",
@@ -1910,7 +1970,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "cainome-cairo-serde 0.2.0",
- "cainome-cairo-serde-derive",
+ "cainome-cairo-serde-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cainome-parser 0.2.0",
  "cainome-rs 0.2.0",
  "cainome-rs-macro 0.2.0",
@@ -1923,6 +1983,32 @@ dependencies = [
  "starknet 0.14.0",
  "starknet-types-core",
  "thiserror 1.0.69",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "cainome"
+version = "0.8.0"
+source = "git+https://github.com/cartridge-gg/cainome?branch=snip12#ef4344c14e2a67d480774fa827a1cc411240de80"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cainome-cairo-serde 0.2.1",
+ "cainome-cairo-serde-derive 0.1.0 (git+https://github.com/cartridge-gg/cainome?branch=snip12)",
+ "cainome-parser 0.3.0",
+ "cainome-rs 0.3.1",
+ "cainome-rs-macro 0.3.0",
+ "camino",
+ "clap",
+ "clap_complete",
+ "convert_case 0.8.0",
+ "serde",
+ "serde_json",
+ "starknet 0.15.1",
+ "starknet-types-core",
+ "thiserror 2.0.12",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -1955,10 +2041,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "cainome-cairo-serde"
+version = "0.2.1"
+source = "git+https://github.com/cartridge-gg/cainome?branch=snip12#ef4344c14e2a67d480774fa827a1cc411240de80"
+dependencies = [
+ "num-bigint",
+ "serde",
+ "serde_with",
+ "starknet 0.15.1",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "cainome-cairo-serde-derive"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d272424141f0ced49ca5f40bc4b756235ee6e7c9cf6ab01f7ef5ac010f5f8864"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "unzip-n",
+]
+
+[[package]]
+name = "cainome-cairo-serde-derive"
+version = "0.1.0"
+source = "git+https://github.com/cartridge-gg/cainome?branch=snip12#ef4344c14e2a67d480774fa827a1cc411240de80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1992,6 +2101,19 @@ dependencies = [
  "starknet 0.14.0",
  "syn 2.0.100",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cainome-parser"
+version = "0.3.0"
+source = "git+https://github.com/cartridge-gg/cainome?branch=snip12#ef4344c14e2a67d480774fa827a1cc411240de80"
+dependencies = [
+ "convert_case 0.8.0",
+ "quote",
+ "serde_json",
+ "starknet 0.15.1",
+ "syn 2.0.100",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2033,6 +2155,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cainome-rs"
+version = "0.3.1"
+source = "git+https://github.com/cartridge-gg/cainome?branch=snip12#ef4344c14e2a67d480774fa827a1cc411240de80"
+dependencies = [
+ "anyhow",
+ "cainome-cairo-serde 0.2.1",
+ "cainome-parser 0.3.0",
+ "camino",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "starknet 0.15.1",
+ "syn 2.0.100",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "cainome-rs-macro"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2068,6 +2208,24 @@ dependencies = [
  "starknet 0.14.0",
  "syn 2.0.100",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cainome-rs-macro"
+version = "0.3.0"
+source = "git+https://github.com/cartridge-gg/cainome?branch=snip12#ef4344c14e2a67d480774fa827a1cc411240de80"
+dependencies = [
+ "anyhow",
+ "cainome-cairo-serde 0.2.1",
+ "cainome-parser 0.3.0",
+ "cainome-rs 0.3.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "starknet 0.15.1",
+ "syn 2.0.100",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2925,6 +3083,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3387,7 +3554,7 @@ dependencies = [
  "serde",
  "serde_json",
  "starknet 0.12.0",
- "starknet-crypto 0.7.4",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "thiserror 1.0.69",
@@ -3933,6 +4100,10 @@ name = "futures-timer"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+dependencies = [
+ "gloo-timers 0.2.6",
+ "send_wrapper",
+]
 
 [[package]]
 name = "futures-util"
@@ -3957,6 +4128,61 @@ name = "futures-utils-wasm"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
+
+[[package]]
+name = "gcloud-sdk"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ec9c312db09dc0dac684dda2f18d76e9ce00effdd27fcaaa90fa811691cd6d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "hyper 1.6.0",
+ "jsonwebtoken",
+ "once_cell",
+ "prost",
+ "prost-types",
+ "reqwest 0.12.15",
+ "secret-vault-value",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tonic",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "gcp_auth"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf67f30198e045a039264c01fb44659ce82402d7771c50938beb41a5ac87733"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "home",
+ "http 1.3.0",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.5",
+ "hyper-util",
+ "ring",
+ "rustls-pemfile 2.2.0",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
+]
 
 [[package]]
 name = "genco"
@@ -4039,6 +4265,39 @@ dependencies = [
  "log",
  "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "gloo-net"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06f627b1a58ca3d42b45d6104bf1e1a03799df472df00988b6ba21accc10580"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-sink",
+ "gloo-utils",
+ "http 1.3.0",
+ "js-sys",
+ "pin-project 1.1.10",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4471,13 +4730,26 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "log",
- "rustls 0.23.23",
+ "rustls 0.23.28",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
  "webpki-roots 0.26.8",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.6.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -4985,12 +5257,41 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fba77a59c4c644fd48732367624d1bcf6f409f9c9a286fbc71d2f1fc0b2ea16"
 dependencies = [
+ "jsonrpsee-client-transport",
  "jsonrpsee-core",
+ "jsonrpsee-http-client",
  "jsonrpsee-proc-macros",
  "jsonrpsee-server",
  "jsonrpsee-types",
+ "jsonrpsee-wasm-client",
+ "jsonrpsee-ws-client",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-client-transport"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a320a3f1464e4094f780c4d48413acd786ce5627aaaecfac9e9c7431d13ae1"
+dependencies = [
+ "base64 0.22.1",
+ "futures-channel",
+ "futures-util",
+ "gloo-net",
+ "http 1.3.0",
+ "jsonrpsee-core",
+ "pin-project 1.1.10",
+ "rustls 0.23.28",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "soketto",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tokio-util",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -5001,21 +5302,47 @@ checksum = "693c93cbb7db25f4108ed121304b671a36002c2db67dff2ee4391a688c738547"
 dependencies = [
  "async-trait",
  "bytes",
+ "futures-timer",
  "futures-util",
  "http 1.3.0",
  "http-body 1.0.1",
  "http-body-util",
  "jsonrpsee-types",
  "parking_lot",
- "pin-project",
+ "pin-project 1.1.10",
  "rand 0.9.0",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
+ "tokio-stream",
  "tower 0.5.2",
  "tracing",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "jsonrpsee-http-client"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6962d2bd295f75e97dd328891e58fce166894b974c1f7ce2e7597f02eeceb791"
+dependencies = [
+ "base64 0.22.1",
+ "http-body 1.0.1",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.5",
+ "hyper-util",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "rustls 0.23.28",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tower 0.5.2",
+ "url",
 ]
 
 [[package]]
@@ -5045,7 +5372,7 @@ dependencies = [
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "pin-project",
+ "pin-project 1.1.10",
  "route-recognizer",
  "serde",
  "serde_json",
@@ -5071,6 +5398,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee-wasm-client"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b67695cbcf4653f39f8f8738925547e0e23fd9fe315bccf951097b9f6a38781"
+dependencies = [
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "tower 0.5.2",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da2694c9ff271a9d3ebfe520f6b36820e85133a51be77a3cb549fd615095261"
+dependencies = [
+ "http 1.3.0",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "tower 0.5.2",
+ "url",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5081,12 +5449,13 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "sha2",
+ "signature",
 ]
 
 [[package]]
 name = "katana-chain-spec"
-version = "1.5.3"
-source = "git+https://github.com/dojoengine/katana?rev=d615ff05#d615ff0573fda269f0de1c8d506c4282a9f1ec8a"
+version = "1.6.0-alpha.1"
+source = "git+https://github.com/dojoengine/katana?rev=40f3261#40f32619bf53730dc61401246fe65278f43f71d4"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -5096,7 +5465,7 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_json",
- "starknet 0.12.0",
+ "starknet 0.14.0",
  "thiserror 1.0.69",
  "toml",
  "url",
@@ -5104,8 +5473,8 @@ dependencies = [
 
 [[package]]
 name = "katana-cli"
-version = "1.5.3"
-source = "git+https://github.com/dojoengine/katana?rev=d615ff05#d615ff0573fda269f0de1c8d506c4282a9f1ec8a"
+version = "1.6.0-alpha.1"
+source = "git+https://github.com/dojoengine/katana?rev=40f3261#40f32619bf53730dc61401246fe65278f43f71d4"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -5131,8 +5500,8 @@ dependencies = [
 
 [[package]]
 name = "katana-core"
-version = "1.5.3"
-source = "git+https://github.com/dojoengine/katana?rev=d615ff05#d615ff0573fda269f0de1c8d506c4282a9f1ec8a"
+version = "1.6.0-alpha.1"
+source = "git+https://github.com/dojoengine/katana?rev=40f3261#40f32619bf53730dc61401246fe65278f43f71d4"
 dependencies = [
  "alloy-provider",
  "alloy-rpc-types-eth",
@@ -5153,7 +5522,7 @@ dependencies = [
  "num-traits",
  "parking_lot",
  "rayon",
- "starknet 0.12.0",
+ "starknet 0.14.0",
  "starknet-types-core",
  "thiserror 1.0.69",
  "tokio",
@@ -5163,8 +5532,8 @@ dependencies = [
 
 [[package]]
 name = "katana-db"
-version = "1.5.3"
-source = "git+https://github.com/dojoengine/katana?rev=d615ff05#d615ff0573fda269f0de1c8d506c4282a9f1ec8a"
+version = "1.6.0-alpha.1"
+source = "git+https://github.com/dojoengine/katana?rev=40f3261#40f32619bf53730dc61401246fe65278f43f71d4"
 dependencies = [
  "anyhow",
  "katana-metrics",
@@ -5182,12 +5551,13 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tracing",
+ "zstd 0.13.3",
 ]
 
 [[package]]
 name = "katana-executor"
-version = "1.5.3"
-source = "git+https://github.com/dojoengine/katana?rev=d615ff05#d615ff0573fda269f0de1c8d506c4282a9f1ec8a"
+version = "1.6.0-alpha.1"
+source = "git+https://github.com/dojoengine/katana?rev=40f3261#40f32619bf53730dc61401246fe65278f43f71d4"
 dependencies = [
  "blockifier",
  "cairo-vm",
@@ -5195,7 +5565,7 @@ dependencies = [
  "katana-provider",
  "parking_lot",
  "quick_cache",
- "starknet 0.12.0",
+ "starknet 0.14.0",
  "starknet_api",
  "thiserror 1.0.69",
  "tracing",
@@ -5203,14 +5573,14 @@ dependencies = [
 
 [[package]]
 name = "katana-feeder-gateway"
-version = "1.5.3"
-source = "git+https://github.com/dojoengine/katana?rev=d615ff05#d615ff0573fda269f0de1c8d506c4282a9f1ec8a"
+version = "1.6.0-alpha.1"
+source = "git+https://github.com/dojoengine/katana?rev=40f3261#40f32619bf53730dc61401246fe65278f43f71d4"
 dependencies = [
  "katana-primitives",
  "katana-rpc-types",
  "reqwest 0.11.27",
  "serde",
- "starknet 0.12.0",
+ "starknet 0.14.0",
  "thiserror 1.0.69",
  "tracing",
  "url",
@@ -5218,8 +5588,8 @@ dependencies = [
 
 [[package]]
 name = "katana-fork"
-version = "1.5.3"
-source = "git+https://github.com/dojoengine/katana?rev=d615ff05#d615ff0573fda269f0de1c8d506c4282a9f1ec8a"
+version = "1.6.0-alpha.1"
+source = "git+https://github.com/dojoengine/katana?rev=40f3261#40f32619bf53730dc61401246fe65278f43f71d4"
 dependencies = [
  "anyhow",
  "futures",
@@ -5227,7 +5597,7 @@ dependencies = [
  "katana-rpc-types",
  "katana-tasks",
  "parking_lot",
- "starknet 0.12.0",
+ "starknet 0.14.0",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -5235,21 +5605,34 @@ dependencies = [
 
 [[package]]
 name = "katana-log"
-version = "1.5.3"
-source = "git+https://github.com/dojoengine/katana?rev=d615ff05#d615ff0573fda269f0de1c8d506c4282a9f1ec8a"
+version = "1.6.0-alpha.1"
+source = "git+https://github.com/dojoengine/katana?rev=40f3261#40f32619bf53730dc61401246fe65278f43f71d4"
 dependencies = [
+ "anyhow",
+ "bytes",
  "clap",
+ "http 1.3.0",
+ "http-body-util",
+ "opentelemetry",
+ "opentelemetry-gcloud-trace",
+ "opentelemetry-http",
+ "opentelemetry-otlp",
+ "opentelemetry-stackdriver",
+ "opentelemetry_sdk",
+ "rustls 0.23.28",
  "serde",
  "thiserror 1.0.69",
+ "tower-http 0.6.6",
  "tracing",
  "tracing-log 0.1.4",
+ "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "katana-messaging"
-version = "1.5.3"
-source = "git+https://github.com/dojoengine/katana?rev=d615ff05#d615ff0573fda269f0de1c8d506c4282a9f1ec8a"
+version = "1.6.0-alpha.1"
+source = "git+https://github.com/dojoengine/katana?rev=40f3261#40f32619bf53730dc61401246fe65278f43f71d4"
 dependencies = [
  "alloy-contract",
  "alloy-network",
@@ -5267,8 +5650,8 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "starknet 0.12.0",
- "starknet-crypto 0.7.4",
+ "starknet 0.14.0",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -5277,8 +5660,8 @@ dependencies = [
 
 [[package]]
 name = "katana-metrics"
-version = "1.5.3"
-source = "git+https://github.com/dojoengine/katana?rev=d615ff05#d615ff0573fda269f0de1c8d506c4282a9f1ec8a"
+version = "1.6.0-alpha.1"
+source = "git+https://github.com/dojoengine/katana?rev=40f3261#40f32619bf53730dc61401246fe65278f43f71d4"
 dependencies = [
  "hyper 0.14.32",
  "jemalloc-ctl",
@@ -5295,8 +5678,8 @@ dependencies = [
 
 [[package]]
 name = "katana-node"
-version = "1.5.3"
-source = "git+https://github.com/dojoengine/katana?rev=d615ff05#d615ff0573fda269f0de1c8d506c4282a9f1ec8a"
+version = "1.6.0-alpha.1"
+source = "git+https://github.com/dojoengine/katana?rev=40f3261#40f32619bf53730dc61401246fe65278f43f71d4"
 dependencies = [
  "anyhow",
  "futures",
@@ -5306,6 +5689,7 @@ dependencies = [
  "katana-core",
  "katana-db",
  "katana-executor",
+ "katana-log",
  "katana-messaging",
  "katana-metrics",
  "katana-pipeline",
@@ -5318,21 +5702,21 @@ dependencies = [
  "katana-tasks",
  "serde",
  "serde_json",
- "starknet 0.12.0",
+ "starknet 0.14.0",
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "thiserror 1.0.69",
  "toml",
  "tower 0.5.2",
- "tower-http",
+ "tower-http 0.6.6",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "katana-pipeline"
-version = "1.5.3"
-source = "git+https://github.com/dojoengine/katana?rev=d615ff05#d615ff0573fda269f0de1c8d506c4282a9f1ec8a"
+version = "1.6.0-alpha.1"
+source = "git+https://github.com/dojoengine/katana?rev=40f3261#40f32619bf53730dc61401246fe65278f43f71d4"
 dependencies = [
  "futures",
  "katana-primitives",
@@ -5345,8 +5729,8 @@ dependencies = [
 
 [[package]]
 name = "katana-pool"
-version = "1.5.3"
-source = "git+https://github.com/dojoengine/katana?rev=d615ff05#d615ff0573fda269f0de1c8d506c4282a9f1ec8a"
+version = "1.6.0-alpha.1"
+source = "git+https://github.com/dojoengine/katana?rev=40f3261#40f32619bf53730dc61401246fe65278f43f71d4"
 dependencies = [
  "futures",
  "katana-executor",
@@ -5360,13 +5744,15 @@ dependencies = [
 
 [[package]]
 name = "katana-primitives"
-version = "1.5.3"
-source = "git+https://github.com/dojoengine/katana?rev=d615ff05#d615ff0573fda269f0de1c8d506c4282a9f1ec8a"
+version = "1.6.0-alpha.1"
+source = "git+https://github.com/dojoengine/katana?rev=40f3261#40f32619bf53730dc61401246fe65278f43f71d4"
 dependencies = [
  "alloy-primitives",
  "anyhow",
  "arbitrary",
  "base64 0.21.7",
+ "blockifier",
+ "cainome-cairo-serde 0.2.0",
  "cairo-lang-starknet-classes",
  "cairo-vm",
  "derive_more 0.99.19",
@@ -5379,8 +5765,8 @@ dependencies = [
  "serde_json",
  "serde_json_pythonic",
  "serde_with",
- "starknet 0.12.0",
- "starknet-crypto 0.7.4",
+ "starknet 0.14.0",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "starknet-types-core",
  "starknet_api",
  "strum 0.25.0",
@@ -5390,8 +5776,8 @@ dependencies = [
 
 [[package]]
 name = "katana-provider"
-version = "1.5.3"
-source = "git+https://github.com/dojoengine/katana?rev=d615ff05#d615ff0573fda269f0de1c8d506c4282a9f1ec8a"
+version = "1.6.0-alpha.1"
+source = "git+https://github.com/dojoengine/katana?rev=40f3261#40f32619bf53730dc61401246fe65278f43f71d4"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -5405,7 +5791,7 @@ dependencies = [
  "katana-trie",
  "parking_lot",
  "serde_json",
- "starknet 0.12.0",
+ "starknet 0.14.0",
  "starknet-types-core",
  "thiserror 1.0.69",
  "tokio",
@@ -5414,17 +5800,18 @@ dependencies = [
 
 [[package]]
 name = "katana-rpc"
-version = "1.5.3"
-source = "git+https://github.com/dojoengine/katana?rev=d615ff05#d615ff0573fda269f0de1c8d506c4282a9f1ec8a"
+version = "1.6.0-alpha.1"
+source = "git+https://github.com/dojoengine/katana?rev=40f3261#40f32619bf53730dc61401246fe65278f43f71d4"
 dependencies = [
- "account_sdk 0.1.0 (git+https://github.com/cartridge-gg/controller?rev=dbbe0353d64de743739d425f8aab91ca3ac0e16f)",
  "anyhow",
- "cainome 0.5.1",
+ "ark-ec 0.4.2",
+ "cainome 0.6.0",
  "futures",
  "http 1.3.0",
  "jsonrpsee",
  "katana-core",
  "katana-executor",
+ "katana-log",
  "katana-metrics",
  "katana-pool",
  "katana-primitives",
@@ -5434,24 +5821,27 @@ dependencies = [
  "katana-rpc-types-builder",
  "katana-tasks",
  "metrics 0.23.0",
+ "num-bigint",
+ "parking_lot",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "starknet 0.12.0",
+ "stark-vrf",
+ "starknet 0.14.0",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.69",
  "tokio",
  "tower 0.5.2",
- "tower-http",
+ "tower-http 0.6.6",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "katana-rpc-api"
-version = "1.5.3"
-source = "git+https://github.com/dojoengine/katana?rev=d615ff05#d615ff0573fda269f0de1c8d506c4282a9f1ec8a"
+version = "1.6.0-alpha.1"
+source = "git+https://github.com/dojoengine/katana?rev=40f3261#40f32619bf53730dc61401246fe65278f43f71d4"
 dependencies = [
- "account_sdk 0.1.0 (git+https://github.com/cartridge-gg/controller?rev=dbbe0353d64de743739d425f8aab91ca3ac0e16f)",
  "anyhow",
  "jsonrpsee",
  "katana-core",
@@ -5462,17 +5852,19 @@ dependencies = [
  "rstest 0.18.2",
  "serde",
  "serde_json",
- "starknet 0.12.0",
+ "starknet 0.14.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "katana-rpc-types"
-version = "1.5.3"
-source = "git+https://github.com/dojoengine/katana?rev=d615ff05#d615ff0573fda269f0de1c8d506c4282a9f1ec8a"
+version = "1.6.0-alpha.1"
+source = "git+https://github.com/dojoengine/katana?rev=40f3261#40f32619bf53730dc61401246fe65278f43f71d4"
 dependencies = [
  "alloy-primitives",
  "anyhow",
+ "cainome 0.6.0",
+ "cainome-cairo-serde 0.2.0",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils",
  "derive_more 0.99.19",
@@ -5484,28 +5876,28 @@ dependencies = [
  "serde_json",
  "serde_json_pythonic",
  "serde_with",
- "starknet 0.12.0",
+ "starknet 0.14.0",
  "starknet_api",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "katana-rpc-types-builder"
-version = "1.5.3"
-source = "git+https://github.com/dojoengine/katana?rev=d615ff05#d615ff0573fda269f0de1c8d506c4282a9f1ec8a"
+version = "1.6.0-alpha.1"
+source = "git+https://github.com/dojoengine/katana?rev=40f3261#40f32619bf53730dc61401246fe65278f43f71d4"
 dependencies = [
  "anyhow",
  "katana-executor",
  "katana-primitives",
  "katana-provider",
  "katana-rpc-types",
- "starknet 0.12.0",
+ "starknet 0.14.0",
 ]
 
 [[package]]
 name = "katana-slot-controller"
-version = "1.5.3"
-source = "git+https://github.com/dojoengine/katana?rev=d615ff05#d615ff0573fda269f0de1c8d506c4282a9f1ec8a"
+version = "1.6.0-alpha.1"
+source = "git+https://github.com/dojoengine/katana?rev=40f3261#40f32619bf53730dc61401246fe65278f43f71d4"
 dependencies = [
  "account_sdk 0.1.0 (git+https://github.com/cartridge-gg/controller?rev=dbbe0353d64de743739d425f8aab91ca3ac0e16f)",
  "katana-primitives",
@@ -5513,8 +5905,8 @@ dependencies = [
 
 [[package]]
 name = "katana-stage"
-version = "1.5.3"
-source = "git+https://github.com/dojoengine/katana?rev=d615ff05#d615ff0573fda269f0de1c8d506c4282a9f1ec8a"
+version = "1.6.0-alpha.1"
+source = "git+https://github.com/dojoengine/katana?rev=40f3261#40f32619bf53730dc61401246fe65278f43f71d4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5530,7 +5922,7 @@ dependencies = [
  "katana-rpc-types",
  "katana-tasks",
  "num-traits",
- "starknet 0.12.0",
+ "starknet 0.14.0",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -5538,8 +5930,8 @@ dependencies = [
 
 [[package]]
 name = "katana-tasks"
-version = "1.5.3"
-source = "git+https://github.com/dojoengine/katana?rev=d615ff05#d615ff0573fda269f0de1c8d506c4282a9f1ec8a"
+version = "1.6.0-alpha.1"
+source = "git+https://github.com/dojoengine/katana?rev=40f3261#40f32619bf53730dc61401246fe65278f43f71d4"
 dependencies = [
  "futures",
  "rayon",
@@ -5552,8 +5944,8 @@ dependencies = [
 
 [[package]]
 name = "katana-trie"
-version = "1.5.3"
-source = "git+https://github.com/dojoengine/katana?rev=d615ff05#d615ff0573fda269f0de1c8d506c4282a9f1ec8a"
+version = "1.6.0-alpha.1"
+source = "git+https://github.com/dojoengine/katana?rev=40f3261#40f32619bf53730dc61401246fe65278f43f71d4"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -5561,7 +5953,7 @@ dependencies = [
  "katana-primitives",
  "serde",
  "slab",
- "starknet 0.12.0",
+ "starknet 0.14.0",
  "starknet-types-core",
  "thiserror 1.0.69",
 ]
@@ -5807,6 +6199,12 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "matrixmultiply"
@@ -6306,6 +6704,128 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "opentelemetry"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-gcloud-trace"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a60e6fa3457bf70cb46055502e3cb31b9c3d7c371d17002f834d47f48046b5da"
+dependencies = [
+ "async-trait",
+ "futures",
+ "gcloud-sdk",
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "rsb_derive",
+ "rvstruct",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.3.0",
+ "opentelemetry",
+ "reqwest 0.12.15",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
+dependencies = [
+ "http 1.3.0",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest 0.12.15",
+ "thiserror 2.0.12",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d059a296a47436748557a353c5e6c5705b9470ef6c95cfc52c21a8814ddac2"
+
+[[package]]
+name = "opentelemetry-stackdriver"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff45646f36750395f550cea066dd33d833957a406182bd4cac3371ece04817a"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "gcp_auth",
+ "hex",
+ "http 1.3.0",
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "prost",
+ "prost-types",
+ "thiserror 2.0.12",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.0",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6435,6 +6955,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "pem"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6520,11 +7050,31 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef0f924a5ee7ea9cbcea77529dba45f8a9ba9f622419fe3386ca581a3ae9d5a"
+dependencies = [
+ "pin-project-internal 0.4.30",
+]
+
+[[package]]
+name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 1.1.10",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851c8d0ce9bebe43790dedfc86614c23494ac9f423dd618d3a61fc693eafe61e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6844,6 +7394,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "quanta"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6887,7 +7469,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.23",
+ "rustls 0.23.28",
  "socket2 0.5.8",
  "thiserror 2.0.12",
  "tokio",
@@ -6905,7 +7487,7 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rustc-hash 2.1.1",
- "rustls 0.23.23",
+ "rustls 0.23.28",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -7188,10 +7770,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
+ "async-compression",
  "base64 0.22.1",
  "bytes",
  "futures-channel",
@@ -7207,11 +7790,13 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.23",
+ "rustls 0.23.28",
+ "rustls-native-certs",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -7220,11 +7805,13 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.2",
+ "tokio-util",
  "tower 0.5.2",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 0.26.8",
  "windows-registry",
@@ -7347,6 +7934,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsb_derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2c53e42fccdc5f1172e099785fe78f89bc0c1e657d0c2ef591efbfac427e9a4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rstest"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7424,9 +8022,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825df406ec217a8116bd7b06897c6cc8f65ffefc15d030ae2c9540acc9ed50b6"
+checksum = "11256b5fe8c68f56ac6f39ef0720e592f33d2367a4782740d9c9142e889c7fb4"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -7442,6 +8040,7 @@ dependencies = [
  "primitive-types",
  "proptest",
  "rand 0.8.5",
+ "rand 0.9.0",
  "rlp",
  "ruint-macro",
  "serde",
@@ -7590,16 +8189,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.23"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki 0.103.3",
  "subtle",
  "zeroize",
 ]
@@ -7644,6 +8243,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
+dependencies = [
+ "core-foundation 0.10.0",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.28",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.3",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs 0.26.11",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7655,9 +8281,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -7681,6 +8307,26 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "rvs_derive"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1fa12378eb54f3d4f2db8dcdbe33af610b7e7d001961c1055858282ecef2a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "rvstruct"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5107860ec34506b64cf3680458074eac5c2c564f7ccc140918bbcd1714fd8d5d"
+dependencies = [
+ "rvs_derive",
 ]
 
 [[package]]
@@ -7784,6 +8430,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "secret-vault-value"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc32a777b53b3433b974c9c26b6d502a50037f8da94e46cb8ce2ced2cfdfaea0"
+dependencies = [
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7832,6 +8491,12 @@ checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
 dependencies = [
  "pest",
 ]
+
+[[package]]
+name = "send_wrapper"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
@@ -8061,6 +8726,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.12",
+ "time",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8105,12 +8782,12 @@ dependencies = [
 name = "slot"
 version = "0.47.0"
 dependencies = [
- "account_sdk 0.1.0 (git+https://github.com/cartridge-gg/controller?rev=05fe96f4)",
+ "account_sdk 0.1.0 (git+https://github.com/cartridge-gg/controller-rs?rev=660ead4)",
  "anyhow",
  "assert_matches",
- "axum",
+ "axum 0.7.9",
  "base64 0.22.1",
- "cainome-cairo-serde 0.2.0",
+ "cainome-cairo-serde 0.2.1",
  "colored 2.2.0",
  "dialoguer",
  "dirs 5.0.1",
@@ -8118,14 +8795,14 @@ dependencies = [
  "hyper 1.6.0",
  "num-bigint",
  "regex",
- "reqwest 0.12.12",
+ "reqwest 0.12.15",
  "serde",
  "serde_json",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
- "tower-http",
+ "tower-http 0.5.2",
  "tracing",
  "update-informer",
  "url",
@@ -8139,7 +8816,7 @@ name = "slot-cli"
 version = "0.47.0"
 dependencies = [
  "anyhow",
- "axum",
+ "axum 0.7.9",
  "chrono",
  "clap",
  "colored 2.2.0",
@@ -8156,7 +8833,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slot",
- "starknet 0.14.0",
+ "starknet 0.15.1",
  "strum_macros 0.25.3",
  "thiserror 1.0.69",
  "tokio",
@@ -8466,6 +9143,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "stark-vrf"
+version = "0.1.0"
+source = "git+https://github.com/dojoengine/stark-vrf.git?rev=96d6d2a#96d6d2a88b1ef46c4a285d0ccc334237205edae3"
+dependencies = [
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "starknet-crypto 0.6.2",
+ "starknet-ff",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "starknet"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8474,8 +9163,8 @@ dependencies = [
  "starknet-accounts 0.11.0",
  "starknet-contract 0.11.0",
  "starknet-core 0.12.1",
- "starknet-crypto 0.7.4",
- "starknet-macros",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-macros 0.2.2",
  "starknet-providers 0.12.1",
  "starknet-signers 0.10.2",
 ]
@@ -8489,9 +9178,9 @@ dependencies = [
  "starknet-accounts 0.12.0",
  "starknet-contract 0.12.0",
  "starknet-core 0.12.1",
- "starknet-core-derive",
- "starknet-crypto 0.7.4",
- "starknet-macros",
+ "starknet-core-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-macros 0.2.2",
  "starknet-providers 0.12.1",
  "starknet-signers 0.10.2",
 ]
@@ -8505,11 +9194,26 @@ dependencies = [
  "starknet-accounts 0.13.0",
  "starknet-contract 0.13.0",
  "starknet-core 0.13.0",
- "starknet-core-derive",
- "starknet-crypto 0.7.4",
- "starknet-macros",
+ "starknet-core-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-macros 0.2.2",
  "starknet-providers 0.13.0",
  "starknet-signers 0.11.0",
+]
+
+[[package]]
+name = "starknet"
+version = "0.15.1"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e#ff4222e7d1a6e3127d864539938680030df77c75"
+dependencies = [
+ "starknet-accounts 0.14.0",
+ "starknet-contract 0.14.0",
+ "starknet-core 0.14.0",
+ "starknet-core-derive 0.1.0 (git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e)",
+ "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e)",
+ "starknet-macros 0.2.3",
+ "starknet-providers 0.14.1",
+ "starknet-signers 0.12.0",
 ]
 
 [[package]]
@@ -8521,7 +9225,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "starknet-core 0.12.1",
- "starknet-crypto 0.7.4",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "starknet-providers 0.12.1",
  "starknet-signers 0.10.2",
  "thiserror 1.0.69",
@@ -8536,7 +9240,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "starknet-core 0.12.1",
- "starknet-crypto 0.7.4",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "starknet-providers 0.12.1",
  "starknet-signers 0.10.2",
  "thiserror 1.0.69",
@@ -8551,9 +9255,23 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "starknet-core 0.13.0",
- "starknet-crypto 0.7.4",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "starknet-providers 0.13.0",
  "starknet-signers 0.11.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "starknet-accounts"
+version = "0.14.0"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e#ff4222e7d1a6e3127d864539938680030df77c75"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "starknet-core 0.14.0",
+ "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e)",
+ "starknet-providers 0.14.1",
+ "starknet-signers 0.12.0",
  "thiserror 1.0.69",
 ]
 
@@ -8603,6 +9321,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "starknet-contract"
+version = "0.14.0"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e#ff4222e7d1a6e3127d864539938680030df77c75"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_with",
+ "starknet-accounts 0.14.0",
+ "starknet-core 0.14.0",
+ "starknet-providers 0.14.1",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "starknet-core"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8620,8 +9352,8 @@ dependencies = [
  "serde_json_pythonic",
  "serde_with",
  "sha3",
- "starknet-core-derive",
- "starknet-crypto 0.7.4",
+ "starknet-core-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "starknet-types-core",
 ]
 
@@ -8643,8 +9375,30 @@ dependencies = [
  "serde_json_pythonic",
  "serde_with",
  "sha3",
- "starknet-core-derive",
- "starknet-crypto 0.7.4",
+ "starknet-core-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-types-core",
+]
+
+[[package]]
+name = "starknet-core"
+version = "0.14.0"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e#ff4222e7d1a6e3127d864539938680030df77c75"
+dependencies = [
+ "base64 0.21.7",
+ "crypto-bigint",
+ "flate2",
+ "foldhash",
+ "hex",
+ "indexmap 2.8.0",
+ "num-traits",
+ "serde",
+ "serde_json",
+ "serde_json_pythonic",
+ "serde_with",
+ "sha3",
+ "starknet-core-derive 0.1.0 (git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e)",
+ "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e)",
  "starknet-types-core",
 ]
 
@@ -8653,6 +9407,16 @@ name = "starknet-core-derive"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b08520b7d80eda7bf1a223e8db4f9bb5779a12846f15ebf8f8d76667eca7f5ad"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "starknet-core-derive"
+version = "0.1.0"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e#ff4222e7d1a6e3127d864539938680030df77c75"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8693,7 +9457,25 @@ dependencies = [
  "num-traits",
  "rfc6979",
  "sha2",
- "starknet-curve 0.5.1",
+ "starknet-curve 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-types-core",
+ "zeroize",
+]
+
+[[package]]
+name = "starknet-crypto"
+version = "0.7.4"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e#ff4222e7d1a6e3127d864539938680030df77c75"
+dependencies = [
+ "crypto-bigint",
+ "hex",
+ "hmac",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "rfc6979",
+ "sha2",
+ "starknet-curve 0.5.1 (git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e)",
  "starknet-types-core",
  "zeroize",
 ]
@@ -8728,15 +9510,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "starknet-curve"
+version = "0.5.1"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e#ff4222e7d1a6e3127d864539938680030df77c75"
+dependencies = [
+ "starknet-types-core",
+]
+
+[[package]]
 name = "starknet-ff"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abf1b44ec5b18d87c1ae5f54590ca9d0699ef4dd5b2ffa66fc97f24613ec585"
 dependencies = [
  "ark-ff 0.4.2",
+ "bigdecimal",
  "crypto-bigint",
  "getrandom 0.2.15",
  "hex",
+ "serde",
 ]
 
 [[package]]
@@ -8746,6 +9538,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb14b6714e7625aca063e91022e574ee0bca863df98071dd7191e24919a367b0"
 dependencies = [
  "starknet-core 0.13.0",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "starknet-macros"
+version = "0.2.3"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e#ff4222e7d1a6e3127d864539938680030df77c75"
+dependencies = [
+ "starknet-core 0.14.0",
  "syn 2.0.100",
 ]
 
@@ -8792,6 +9593,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "starknet-providers"
+version = "0.14.1"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e#ff4222e7d1a6e3127d864539938680030df77c75"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "ethereum-types",
+ "flate2",
+ "getrandom 0.2.15",
+ "log",
+ "reqwest 0.12.15",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "starknet-core 0.14.0",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "starknet-signers"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8804,7 +9625,7 @@ dependencies = [
  "getrandom 0.2.15",
  "rand 0.8.5",
  "starknet-core 0.12.1",
- "starknet-crypto 0.7.4",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.69",
 ]
 
@@ -8821,7 +9642,23 @@ dependencies = [
  "getrandom 0.2.15",
  "rand 0.8.5",
  "starknet-core 0.13.0",
- "starknet-crypto 0.7.4",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "starknet-signers"
+version = "0.12.0"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e#ff4222e7d1a6e3127d864539938680030df77c75"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "crypto-bigint",
+ "eth-keystore",
+ "getrandom 0.2.15",
+ "rand 0.8.5",
+ "starknet-core 0.14.0",
+ "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e)",
  "thiserror 1.0.69",
 ]
 
@@ -8870,7 +9707,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "size-of",
- "starknet-crypto 0.7.4",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "starknet-types-core",
  "strum 0.25.0",
  "strum_macros 0.25.3",
@@ -9300,7 +10137,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.23",
+ "rustls 0.23.28",
  "tokio",
 ]
 
@@ -9367,6 +10204,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+dependencies = [
+ "async-trait",
+ "axum 0.8.4",
+ "base64 0.22.1",
+ "bytes",
+ "flate2",
+ "h2 0.4.8",
+ "http 1.3.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project 1.1.10",
+ "prost",
+ "rustls-native-certs",
+ "socket2 0.5.8",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tokio-stream",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "torii-cli"
 version = "1.4.1"
 source = "git+https://github.com/dojoengine/dojo?branch=torii-sqlite-types#821845a78cfdf2432f5af6d60b0eed6a268c83f9"
@@ -9403,8 +10272,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
- "futures-util",
- "pin-project",
  "pin-project-lite",
  "tokio",
  "tokio-util",
@@ -9439,8 +10306,25 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
+ "bitflags 2.9.0",
+ "bytes",
+ "http 1.3.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
  "async-compression",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitflags 2.9.0",
  "bytes",
  "futures-core",
@@ -9457,7 +10341,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -9475,6 +10359,18 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tower-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1093c19826d33807c72511e68f73b4a0469a3f22c2bd5f7d5212178b4b89674"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project 0.4.30",
+ "tower-service",
+]
 
 [[package]]
 name = "tracing"
@@ -9510,6 +10406,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project 1.1.10",
+ "tracing",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9529,6 +10435,24 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log 0.2.0",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -9755,7 +10679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53813bf5d5f0d8430794f8cc48e99521cc9e298066958d16383ccb8b39d182a7"
 dependencies = [
  "etcetera",
- "reqwest 0.12.12",
+ "reqwest 0.12.15",
  "semver 1.0.26",
  "serde",
  "serde_json",
@@ -9772,7 +10696,7 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls 0.23.23",
+ "rustls 0.23.28",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -10049,6 +10973,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10083,6 +11020,24 @@ dependencies = [
  "raw-window-handle",
  "url",
  "web-sys",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.1",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86138b15b2b7d561bc4469e77027b8dd005a43dc502e9031d1f5afc8ce1f280e"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -10305,13 +11260,13 @@ dependencies = [
 
 [[package]]
 name = "windows-registry"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
+ "windows-result 0.3.1",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -10426,11 +11381,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -10452,6 +11423,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10468,6 +11445,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10488,10 +11471,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -10512,6 +11507,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10528,6 +11529,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -10548,6 +11555,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10564,6 +11577,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ serde = "1"
 serde_json = "1.0.133"
 thiserror = "1.0.32"
 url = "2.2.2"
-starknet = "0.14.0"
+starknet = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ff4222e" }
 num-bigint = "0.4.3"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,13 +18,8 @@ log = "0.4"
 graphql_client.workspace = true
 torii-cli = { git = "https://github.com/dojoengine/dojo", branch = "torii-sqlite-types", default-features = false }
 
-# Revision that includes the `config` field being public.
-# Should be bumped once a new version is released with this commit:
-# <https://github.com/dojoengine/katana/commit/d9514a9996c51bd8083da9b7fd1029a41480cfdd>
-katana-primitives = { git = "https://github.com/dojoengine/katana", rev = "d615ff05" }
-katana-cli = { git = "https://github.com/dojoengine/katana", rev = "d615ff05", default-features = false, features = [
-	"cartridge",
-] }
+katana-primitives = { git = "https://github.com/dojoengine/katana", rev = "40f3261" }
+katana-cli = { git = "https://github.com/dojoengine/katana", rev = "40f3261", default-features = false, features = [ "cartridge" ] }
 
 comfy-table = "7.1"
 hyper.workspace = true

--- a/slot/Cargo.toml
+++ b/slot/Cargo.toml
@@ -8,7 +8,7 @@ rust-version.workspace = true
 [dependencies]
 anyhow.workspace = true
 axum.workspace = true
-cainome-cairo-serde = "0.2.0"
+cainome-cairo-serde = { git = "https://github.com/cartridge-gg/cainome", branch = "snip12" }
 dirs = "5"
 graphql_client.workspace = true
 reqwest = { version = "0.12", default-features = false, features = [
@@ -27,8 +27,7 @@ starknet.workspace = true
 url.workspace = true
 tempfile = "3.10.1"
 hyper.workspace = true
-# https://github.com/cartridge-gg/controller/pull/1549
-account_sdk = { git = "https://github.com/cartridge-gg/controller", rev = "05fe96f4" }
+account_sdk = { git = "https://github.com/cartridge-gg/controller-rs", rev = "660ead4" }
 base64 = "0.22.1"
 colored = "2.0.0"
 num-bigint = { version = "0.4.6", features = ["serde"] }

--- a/slot/src/utils.rs
+++ b/slot/src/utils.rs
@@ -13,7 +13,7 @@ static EMAIL_REGEX: OnceLock<Regex> = OnceLock::new();
 /// If this function is called in a test environment, path to a temporary directory is returned instead.
 pub fn config_dir() -> PathBuf {
     let path = if cfg!(test) {
-        tempfile::tempdir().unwrap().into_path()
+        tempfile::tempdir().unwrap().keep()
     } else {
         dirs::config_local_dir().expect("unsupported OS")
     }


### PR DESCRIPTION
This PR aims at updating the starknet-rs version and using controller-rs instead of the old controller repo which is not up to date when it comes to rust bindings.