### PR TITLE
feat(paymaster): display USD instead of credits

### DIFF
--- a/cli/src/command/paymaster/budget.rs
+++ b/cli/src/command/paymaster/budget.rs
@@ -86,12 +86,7 @@ impl BudgetCmd {
 
         println!("\n💰 New Budget:");
         if usd_equivalent > 0.0 {
-            println!(
-                "  • Amount: {} {} (${:.2} USD)",
-                new_budget_formatted as i64,
-                args.unit.to_uppercase(),
-                usd_equivalent
-            );
+            println!("  • Amount: ${:.2} USD", usd_equivalent);
         } else {
             println!(
                 "  • Amount: {} {}",
@@ -145,12 +140,7 @@ impl BudgetCmd {
 
         println!("\n💰 New Budget:");
         if usd_equivalent > 0.0 {
-            println!(
-                "  • Amount: {} {} (${:.2} USD)",
-                new_budget_formatted as i64,
-                args.unit.to_uppercase(),
-                usd_equivalent
-            );
+            println!("  • Amount: ${:.2} USD", usd_equivalent);
         } else {
             println!(
                 "  • Amount: {} {}",

--- a/cli/src/command/paymaster/budget.rs
+++ b/cli/src/command/paymaster/budget.rs
@@ -25,7 +25,7 @@ enum BudgetSubcommand {
 
 #[derive(Debug, Args)]
 struct IncreaseBudgetArgs {
-    #[arg(long, help = "Amount to decrease the budget.")]
+    #[arg(long, help = "Amount to increase the budget.")]
     amount: u64,
     #[arg(long, help = "Unit for the budget (USD or STRK).")]
     unit: String,
@@ -51,10 +51,7 @@ impl BudgetCmd {
         let credentials = Credentials::load()?;
 
         let (unit, amount_for_api) = match args.unit.to_uppercase().as_str() {
-            "USD" => (
-                IncreaseBudgetFeeUnit::CREDIT,
-                (args.amount as f64 * 100.0) as i64,
-            ), // Convert USD to credits
+            "USD" => (IncreaseBudgetFeeUnit::CREDIT, (args.amount * 100) as i64), // Convert USD to credits
             "STRK" => (IncreaseBudgetFeeUnit::STRK, args.amount as i64),
             _ => {
                 return Err(anyhow::anyhow!(
@@ -108,10 +105,7 @@ impl BudgetCmd {
         let credentials = Credentials::load()?;
 
         let (unit, amount_for_api) = match args.unit.to_uppercase().as_str() {
-            "USD" => (
-                DecreaseBudgetFeeUnit::CREDIT,
-                (args.amount as f64 * 100.0) as i64,
-            ), // Convert USD to credits
+            "USD" => (DecreaseBudgetFeeUnit::CREDIT, (args.amount * 100) as i64), // Convert USD to credits
             "STRK" => (DecreaseBudgetFeeUnit::STRK, args.amount as i64),
             _ => {
                 return Err(anyhow::anyhow!(

--- a/cli/src/command/paymaster/create.rs
+++ b/cli/src/command/paymaster/create.rs
@@ -57,12 +57,7 @@ impl CreateArgs {
 
         println!("\n💰 Initial Budget:");
         if usd_equivalent > 0.0 {
-            println!(
-                "  • Amount: {} {} (${:.2} USD)",
-                budget_formatted as i64,
-                self.unit.to_uppercase(),
-                usd_equivalent
-            );
+            println!("  • Amount: ${:.2} USD", usd_equivalent);
         } else {
             println!(
                 "  • Amount: {} {}",

--- a/cli/src/command/paymaster/create.rs
+++ b/cli/src/command/paymaster/create.rs
@@ -23,7 +23,7 @@ impl CreateArgs {
         let credentials = Credentials::load()?;
 
         let (unit, budget_for_api) = match self.unit.to_uppercase().as_str() {
-            "USD" => (FeeUnit::CREDIT, (self.budget as f64 * 100.0) as i64), // Convert USD to credits
+            "USD" => (FeeUnit::CREDIT, (self.budget * 100) as i64), // Convert USD to credits
             "STRK" => (FeeUnit::STRK, self.budget as i64),
             _ => {
                 return Err(anyhow::anyhow!(

--- a/cli/src/command/paymaster/create.rs
+++ b/cli/src/command/paymaster/create.rs
@@ -25,7 +25,12 @@ impl CreateArgs {
         let (unit, budget_for_api) = match self.unit.to_uppercase().as_str() {
             "USD" => (FeeUnit::CREDIT, (self.budget as f64 * 100.0) as i64), // Convert USD to credits
             "STRK" => (FeeUnit::STRK, self.budget as i64),
-            _ => return Err(anyhow::anyhow!("Invalid unit: {}", self.unit)),
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "Invalid unit: {}. Supported units: USD, STRK",
+                    self.unit
+                ))
+            }
         };
 
         let variables = create_paymaster::Variables {

--- a/cli/src/command/paymaster/info.rs
+++ b/cli/src/command/paymaster/info.rs
@@ -29,13 +29,6 @@ impl InfoArgs {
                 let strk_fees_formatted = paymaster.strk_fees as f64 / 1e6;
                 let credit_fees_formatted = paymaster.credit_fees as f64 / 1e6;
 
-                // Convert budget fee unit to string (for future use)
-                let _budget_unit = match paymaster.budget_fee_unit {
-                    PaymasterBudgetFeeUnit::CREDIT => "CREDIT",
-                    PaymasterBudgetFeeUnit::STRK => "STRK",
-                    _ => "UNKNOWN",
-                };
-
                 // Calculate usage percentage and create progress bar
                 let spent_amount = match paymaster.budget_fee_unit {
                     PaymasterBudgetFeeUnit::STRK => strk_fees_formatted,

--- a/cli/src/command/paymaster/info.rs
+++ b/cli/src/command/paymaster/info.rs
@@ -29,8 +29,8 @@ impl InfoArgs {
                 let strk_fees_formatted = paymaster.strk_fees as f64 / 1e6;
                 let credit_fees_formatted = paymaster.credit_fees as f64 / 1e6;
 
-                // Convert budget fee unit to string
-                let budget_unit = match paymaster.budget_fee_unit {
+                // Convert budget fee unit to string (for future use)
+                let _budget_unit = match paymaster.budget_fee_unit {
                     PaymasterBudgetFeeUnit::CREDIT => "CREDIT",
                     PaymasterBudgetFeeUnit::STRK => "STRK",
                     _ => "UNKNOWN",
@@ -86,10 +86,7 @@ impl InfoArgs {
                 };
 
                 if usd_equivalent > 0.0 {
-                    println!(
-                        "  • Total: {} {} (${:.2} USD)",
-                        budget_formatted as i64, budget_unit, usd_equivalent
-                    );
+                    println!("  • Total: ${:.2} USD", usd_equivalent);
                 } else {
                     println!("  • Total: NONE (Please Top Up)");
                 }
@@ -101,10 +98,7 @@ impl InfoArgs {
                     }
                     PaymasterBudgetFeeUnit::CREDIT => {
                         let spent_usd_equivalent = credit_fees_formatted * 0.01; // 100 credit = 1 USD
-                        println!(
-                            "  • Spent: {:.2} CREDIT (${:.2} USD)",
-                            credit_fees_formatted, spent_usd_equivalent
-                        );
+                        println!("  • Spent: ${:.2} USD", spent_usd_equivalent);
                     }
                     _ => {}
                 }

--- a/cli/src/command/paymasters/list.rs
+++ b/cli/src/command/paymasters/list.rs
@@ -60,15 +60,16 @@ impl ListArgs {
                 // Populate the table
                 for (team_node, pm_node) in paymasters_data {
                     paymasters_found = true;
-                    let budget = format!(
-                        "{} {}",
-                        pm_node.budget / BUDGET_DECIMALS,
-                        match pm_node.budget_fee_unit {
-                            PaymasterBudgetFeeUnit::CREDIT => "CREDIT",
-                            PaymasterBudgetFeeUnit::STRK => "STRK",
-                            _ => "UNKNOWN",
+                    let budget = match pm_node.budget_fee_unit {
+                        PaymasterBudgetFeeUnit::CREDIT => {
+                            let usd_amount = (pm_node.budget / BUDGET_DECIMALS) as f64 * 0.01;
+                            format!("${:.2} USD", usd_amount)
                         }
-                    );
+                        PaymasterBudgetFeeUnit::STRK => {
+                            format!("{} STRK", pm_node.budget / BUDGET_DECIMALS)
+                        }
+                        _ => "UNKNOWN".to_string(),
+                    };
                     table.add_row(vec![
                         Cell::new(pm_node.name.as_str()),
                         Cell::new(&team_node.name),


### PR DESCRIPTION
Remove credit references from user-facing displays and show only USD values.
Maintains 100:1 credit to USD conversion ratio while hiding the underlying
credit system from users.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>