### PR TITLE
fix(cli): remove insane from the listed tiers

### DIFF
--- a/cli/src/command/deployments/mod.rs
+++ b/cli/src/command/deployments/mod.rs
@@ -71,6 +71,7 @@ pub enum Tier {
     Pro,
     Epic,
     Legendary,
+    #[clap(skip)]
     Insane,
 }
 


### PR DESCRIPTION
Small fix to avoid people attempting to use `insane` for new comers or if they didn't read the notice/doc.