### PR TITLE
feat(auth): add token command for auth token display

### DIFF
--- a/cli/src/command/auth/mod.rs
+++ b/cli/src/command/auth/mod.rs
@@ -1,4 +1,4 @@
-use self::{email::EmailArgs, info::InfoArgs, login::LoginArgs};
+use self::{email::EmailArgs, info::InfoArgs, login::LoginArgs, token::TokenArgs};
 use crate::command::auth::fund::FundArgs;
 use crate::command::auth::transfer::TransferArgs;
 use anyhow::Result;
@@ -9,6 +9,7 @@ mod fund;
 mod info;
 mod login;
 mod session;
+mod token;
 mod transfer;
 
 #[derive(Subcommand, Debug)]
@@ -28,6 +29,9 @@ pub enum Auth {
     #[command(about = "Transfer funds to a slot team.")]
     Transfer(TransferArgs),
 
+    #[command(about = "Display the current auth token.")]
+    Token(TokenArgs),
+
     // Mostly for testing purposes, will eventually turn it into a library call from `sozo`.
     #[command(hide = true)]
     CreateSession(session::CreateSession),
@@ -42,6 +46,7 @@ impl Auth {
             Auth::SetEmail(args) => args.run().await,
             Auth::Fund(args) => args.run().await,
             Auth::Transfer(args) => args.run().await,
+            Auth::Token(args) => args.run().await,
         }
     }
 }

--- a/cli/src/command/auth/token.rs
+++ b/cli/src/command/auth/token.rs
@@ -1,0 +1,33 @@
+use anyhow::Result;
+use clap::Args;
+use slot::credential::Credentials;
+
+#[derive(Debug, Args)]
+pub struct TokenArgs;
+
+impl TokenArgs {
+    pub async fn run(&self) -> Result<()> {
+        let credentials = Credentials::load()?;
+
+        eprintln!();
+        eprintln!(
+            "WARNING: This token provides access to your account for slot actions. Keep it safe."
+        );
+        eprintln!();
+
+        // Print the raw token
+        println!("{}", credentials.access_token.token);
+
+        // Print usage instructions to stderr so they don't interfere with token parsing
+        eprintln!();
+        eprintln!("You can use this token for programmatic authentication by setting:");
+        eprintln!(
+            "export SLOT_AUTH='{}'",
+            serde_json::to_string(&credentials)?
+        );
+        eprintln!();
+        eprintln!("This is useful for CI/CD pipelines and scripts where interactive authentication is not possible.");
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Introduced a new `token` command to display the current authentication token. Includes usage instructions for programmatic authentication, useful in CI/CD pipelines or scripts where interactive authentication is not feasible.