### PR TITLE
fix(deployments): warn about ignored metrics in config

### DIFF
--- a/cli/src/command/deployments/mod.rs
+++ b/cli/src/command/deployments/mod.rs
@@ -135,6 +135,9 @@ pub(crate) fn warn_checks(config_path: &std::path::Path) -> Result<()> {
                     println!("⚠️  Warning: 'events_chunk_size' option found in config file but is ignored and overridden in slot.");
                 }
             }
+            if parsed.get("metrics").is_some() {
+                println!("⚠️  Warning: 'metrics' section found in config file but is ignored and overridden in slot. Metrics are always collected and available at /metrics of your slot deployment URL.");
+            }
         }
     }
     Ok(())


### PR DESCRIPTION
Added a warning message for 'metrics' found in the config file, notifying users that it is ignored and overridden in slot. Metrics are always collected and accessible at the deployment URL.