### PR TITLE
Rename entryPoint to entrypoint for consistency

### DIFF
--- a/cli/src/command/paymaster/policy.rs
+++ b/cli/src/command/paymaster/policy.rs
@@ -46,7 +46,7 @@ enum PolicySubcommand {
 struct AddJsonPolicyArgs {
     #[arg(
         long,
-        help = "Path to a JSON file containing an array of policies to add. Each policy should have 'contractAddress', 'entryPoint', and 'selector'."
+        help = "Path to a JSON file containing an array of policies to add. Each policy should have 'contractAddress', 'entrypoint', and 'selector'."
     )]
     file: PathBuf,
 }

--- a/slot/src/preset.rs
+++ b/slot/src/preset.rs
@@ -109,6 +109,6 @@ pub struct PaymasterPolicyInput {
     #[serde(rename = "contractAddress")]
     pub contract_address: String,
 
-    #[serde(rename = "entryPoint")]
+    #[serde(rename = "entrypoint")]
     pub entry_point: String,
 }


### PR DESCRIPTION
This PR addresses issue #314 by renaming `entryPoint` to `entrypoint` for consistency throughout the codebase.

## Changes
- Updated `PaymasterPolicyInput` serde rename from `entryPoint` to `entrypoint` in `slot/src/preset.rs`
- Updated CLI help text to reference `entrypoint` instead of `entryPoint`

Resolves #314

Generated with [Claude Code](https://claude.ai/code)