### PR TITLE
feat(merkle-drops): add --json-file option to create command

### DIFF
--- a/test_merkle_drop.json
+++ b/test_merkle_drop.json
@@ -1,0 +1,13 @@
+{
+  "name": "test-merkle-drop",
+  "network": "ETH",
+  "description": "Test merkle drop from build output",
+  "claim_contract": "0x1234567890abcdef1234567890abcdef12345678",
+  "entrypoint": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+  "merkle_root": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+  "snapshot": [
+    ["0x1111111111111111111111111111111111111111", [1, 2, 3]],
+    ["0x2222222222222222222222222222222222222222", [4, 5, 6]],
+    ["0x3333333333333333333333333333333333333333", [7, 8, 9]]
+  ]
+}


### PR DESCRIPTION
## Summary
- Add support for reading JSON output from `slot merkle-drops build` command
- Enables seamless workflow from building to creating merkle drops

## Changes
- Added `--json-file` option to the `slot merkle-drops create json` subcommand
- Implemented `MerkleDropBuildOutput` struct to parse build command output
- Extract metadata (name, description, claim_contract, entrypoint, merkle_root) from JSON
- Use snapshot array to construct claims for the API
- Skip prompting for parameters when using JSON file input
- Maintain backward compatibility with existing configuration format

## Usage
```bash
# Step 1: Build merkle drop data from on-chain token holders
slot merkle-drops build \
  --name "my-drop" \
  --contract-address 0x123... \
  --rpc-url https://... \
  --output merkle_drop.json

# Step 2: Create merkle drop from build output
slot merkle-drops create json --json-file merkle_drop.json
```

## Test Plan
- [x] Code compiles and passes formatting checks
- [ ] Test with actual build output JSON file
- [ ] Verify backward compatibility with old configuration format
- [ ] Integration test with full build → create workflow

🤖 Generated with [Claude Code](https://claude.ai/code)