### PR TITLE
ci(workflows): add daily GraphQL schema sync workflow

### DIFF
--- a/.github/workflows/schema-sync.yml
+++ b/.github/workflows/schema-sync.yml
@@ -1,0 +1,57 @@
+name: Daily Schema Sync
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # Run daily at 2 AM UTC
+  workflow_dispatch: # Allow manual triggering
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync-schema:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install GraphQL CLI
+        run: cargo install graphql_client_cli
+
+      - name: Run schema pull
+        run: sh scripts/pull_schema.sh prod
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update GraphQL schema from production"
+          title: "🔄 Daily Schema Sync"
+          body: |
+            ## Summary
+
+            Automated daily sync of GraphQL schema from production environment.
+
+            This PR was automatically created by the daily schema sync workflow.
+
+            ## Changes
+
+            - Updated `slot/src/graphql/schema.graphql` from production API
+            - Generated Rust code will be updated on merge if schema changed
+
+            ## Next Steps
+
+            - Review schema changes for breaking changes
+            - Ensure generated code still compiles
+            - Merge if changes look good
+          branch: chore/daily-schema-sync
+          branch-suffix: timestamp
+          delete-branch: true
+          assignees: ${{ github.actor }}

--- a/.github/workflows/schema-sync.yml
+++ b/.github/workflows/schema-sync.yml
@@ -57,4 +57,3 @@ jobs:
           branch: chore/daily-schema-sync
           branch-suffix: timestamp
           delete-branch: true
-          assignees: ${{ github.actor }}

--- a/.github/workflows/schema-sync.yml
+++ b/.github/workflows/schema-sync.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: update GraphQL schema from production"
-          title: "🔄 Daily Schema Sync"
+          title: "chore(graphql): sync schema"
           body: |
             ## Summary
 

--- a/.github/workflows/schema-sync.yml
+++ b/.github/workflows/schema-sync.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: '0 2 * * *' # Run daily at 2 AM UTC
   workflow_dispatch: # Allow manual triggering
-  push:
-    branches:
-      - "ci/sync"
 
 permissions:
   contents: write

--- a/slot/schema.json
+++ b/slot/schema.json
@@ -5,6 +5,16 @@
         {
           "args": [
             {
+              "defaultValue": "true",
+              "description": null,
+              "name": "if",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            {
               "defaultValue": null,
               "description": null,
               "name": "label",
@@ -13,18 +23,8 @@
                 "name": "String",
                 "ofType": null
               }
-            },
-						{
-							"defaultValue": "true",
-							"description": null,
-							"name": "if",
-							"type": {
-								"kind": "SCALAR",
-								"name": "Boolean",
-								"ofType": null
-							}
-						}
-					],
+            }
+          ],
           "description": "The @defer directive may be specified on a fragment spread to imply de-prioritization, that causes the fragment to be omitted in the initial response, and delivered as a subsequent response afterward. A query with @defer directive will cause the request to potentially return multiple responses, where non-deferred data is delivered in the initial response and data deferred delivered in a subsequent response. @include and @skip take precedence over @defer.",
           "locations": [
             "FRAGMENT_SPREAD",

--- a/slot/schema.json
+++ b/slot/schema.json
@@ -5,16 +5,6 @@
         {
           "args": [
             {
-              "defaultValue": "true",
-              "description": null,
-              "name": "if",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            {
               "defaultValue": null,
               "description": null,
               "name": "label",
@@ -23,8 +13,18 @@
                 "name": "String",
                 "ofType": null
               }
-            }
-          ],
+            },
+						{
+							"defaultValue": "true",
+							"description": null,
+							"name": "if",
+							"type": {
+								"kind": "SCALAR",
+								"name": "Boolean",
+								"ofType": null
+							}
+						}
+					],
           "description": "The @defer directive may be specified on a fragment spread to imply de-prioritization, that causes the fragment to be omitted in the initial response, and delivered as a subsequent response afterward. A query with @defer directive will cause the request to potentially return multiple responses, where non-deferred data is delivered in the initial response and data deferred delivered in a subsequent response. @include and @skip take precedence over @defer.",
           "locations": [
             "FRAGMENT_SPREAD",


### PR DESCRIPTION
Added a GitHub Actions workflow to automate daily syncing of the GraphQL schema from the production API. The workflow runs daily at 2 AM UTC and creates pull requests with schema updates for streamlined review and integration. Includes manual triggering support for on-demand updates.