### PR TITLE
Refactor merkle-drop build to snapshot command

### DIFF
--- a/cli/src/command/merkle_drops/mod.rs
+++ b/cli/src/command/merkle_drops/mod.rs
@@ -2,16 +2,16 @@ use anyhow::Result;
 use clap::Subcommand;
 
 // Import the structs defined in the subcommand files
-use self::build::BuildArgs;
 use self::create::CreateArgs;
-mod build;
+use self::snapshot::SnapshotArgs;
 mod create;
+mod snapshot;
 
 #[derive(Subcommand, Debug)]
 #[command(next_help_heading = "Merkle drops options")]
 pub enum MerkleDropsCmd {
-    #[command(about = "Build a merkle tree from onchain token holders.", aliases = ["b"])]
-    Build(BuildArgs),
+    #[command(about = "Generate a snapshot of onchain token holders.", aliases = ["s"])]
+    Snapshot(SnapshotArgs),
     #[command(about = "Create a new merkle drop.", aliases = ["c"])]
     Create(CreateArgs),
 }
@@ -19,7 +19,7 @@ pub enum MerkleDropsCmd {
 impl MerkleDropsCmd {
     pub async fn run(&self) -> Result<()> {
         match self {
-            Self::Build(args) => args.run().await,
+            Self::Snapshot(args) => args.run().await,
             Self::Create(args) => args.run().await,
         }
     }

--- a/cli/src/command/merkle_drops/snapshot.rs
+++ b/cli/src/command/merkle_drops/snapshot.rs
@@ -1,8 +1,6 @@
 use anyhow::Result;
 use clap::Args;
 use serde_json::json;
-use slot::merkle::{build_merkle_tree, MerkleClaimData};
-use starknet::core::types::Felt;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -22,9 +20,9 @@ abigen!(
 );
 
 #[derive(Debug, Args)]
-#[command(next_help_heading = "Build merkle drop options")]
-pub struct BuildArgs {
-    #[arg(long, help = "Name for the merkle drop")]
+#[command(next_help_heading = "Snapshot options")]
+pub struct SnapshotArgs {
+    #[arg(long, help = "Name for the snapshot")]
     name: String,
 
     #[arg(long, help = "Contract address to query for token holders")]
@@ -39,14 +37,8 @@ pub struct BuildArgs {
     #[arg(long, help = "Network name (e.g., ETH, BASE)", default_value = "ETH")]
     network: String,
 
-    #[arg(long, help = "Description of the merkle drop")]
+    #[arg(long, help = "Description of the snapshot")]
     description: String,
-
-    #[arg(long, help = "Claim contract address for the merkle drop")]
-    claim_contract: String,
-
-    #[arg(long, help = "Entrypoint address for claiming")]
-    entrypoint: String,
 
     #[arg(
         long,
@@ -62,8 +54,8 @@ pub struct BuildArgs {
 
     #[arg(
         long,
-        help = "Output file path for the merkle drop JSON data",
-        default_value = "merkle_drop.json"
+        help = "Output file path for the snapshot JSON data",
+        default_value = "snapshot.json"
     )]
     output: PathBuf,
 
@@ -78,10 +70,10 @@ pub struct BuildArgs {
     concurrency: usize,
 }
 
-impl BuildArgs {
+impl SnapshotArgs {
     pub async fn run(&self) -> Result<()> {
         println!(
-            "Building merkle tree for contract: {}",
+            "Generating snapshot for contract: {}",
             self.contract_address
         );
         println!("RPC URL: {}", self.rpc_url);
@@ -110,48 +102,17 @@ impl BuildArgs {
 
         println!("Found {} unique holders", holders.len());
 
-        // Convert to merkle claim data format
-        let mut merkle_data: Vec<MerkleClaimData> = holders
-            .into_iter()
-            .map(|(address, token_ids)| {
-                // Convert token_ids to Felt array
-                let data: Vec<Felt> = token_ids.iter().map(|id| Felt::from(*id as u64)).collect();
-                MerkleClaimData { address, data }
-            })
-            .collect();
-
-        merkle_data.sort_by(|a, b| {
-            let a = Felt::from_hex(&a.address).unwrap_or_default();
-            let b = Felt::from_hex(&b.address).unwrap_or_default();
-            a.cmp(&b)
-        });
-
-        // Build merkle tree
-        println!("Building merkle tree...");
-        let (root, _proofs) = build_merkle_tree(&merkle_data)?;
-
-        println!("Merkle root: 0x{}", hex::encode(&root));
+        // Convert holders to sorted list
+        let mut sorted_holders: Vec<(String, Vec<i64>)> = holders.into_iter().collect();
+        sorted_holders.sort_by(|a, b| a.0.cmp(&b.0));
 
         // Prepare snapshot data
-        let snapshot: Vec<Vec<serde_json::Value>> = merkle_data
+        let snapshot: Vec<Vec<serde_json::Value>> = sorted_holders
             .iter()
-            .map(|claim| {
-                // Convert Felt data back to numeric values for JSON output
-                let token_ids: Vec<i64> = claim
-                    .data
-                    .iter()
-                    .map(|f| {
-                        // Convert Felt to u64 then to i64
-                        // This assumes token IDs fit in i64 range
-                        let bytes = f.to_bytes_be();
-                        let mut value = 0u64;
-                        for (i, &byte) in bytes.iter().rev().enumerate().take(8) {
-                            value |= (byte as u64) << (i * 8);
-                        }
-                        value as i64
-                    })
-                    .collect();
-                vec![json!(claim.address), json!(token_ids)]
+            .map(|(address, token_ids)| {
+                let mut sorted_ids = token_ids.clone();
+                sorted_ids.sort();
+                vec![json!(address), json!(sorted_ids)]
             })
             .collect();
 
@@ -160,9 +121,8 @@ impl BuildArgs {
             "name": self.name,
             "network": self.network,
             "description": self.description,
-            "claim_contract": self.claim_contract,
-            "entrypoint": self.entrypoint,
-            "merkle_root": format!("0x{}", hex::encode(&root)),
+            "contract_address": self.contract_address,
+            "block_height": self.block_height,
             "snapshot": snapshot
         });
 
@@ -170,15 +130,14 @@ impl BuildArgs {
         let output_str = serde_json::to_string_pretty(&output_data)?;
         std::fs::write(&self.output, output_str)?;
 
-        println!("Merkle drop data written to: {}", self.output.display());
+        println!("Snapshot data written to: {}", self.output.display());
         println!("\nSummary:");
-        println!("  Total unique holders: {}", merkle_data.len());
-        println!("  Merkle root: 0x{}", hex::encode(&root));
+        println!("  Total unique holders: {}", sorted_holders.len());
         println!("  Output file: {}", self.output.display());
         println!("\nNext steps:");
         println!("1. Review the generated snapshot data");
         println!(
-            "2. Use 'slot merkle-drops create json --file {}' to create the merkle drop",
+            "2. Use 'slot merkle-drops create --json-file {}' to create a merkle drop from this snapshot",
             self.output.display()
         );
 

--- a/docs/merkle_drop.md
+++ b/docs/merkle_drop.md
@@ -10,32 +10,30 @@ The merkle root is automatically calculated server-side from the provided claims
 
 ## Commands
 
-### Build Merkle Tree
+### Generate Snapshot
 
-Build a merkle tree by querying token holders from an on-chain NFT contract via RPC.
+Generate a snapshot of token holders from an on-chain NFT contract via RPC.
 
-**Aliases:** `slot md b`
+**Aliases:** `slot md s`
 
 ```bash
-slot merkle-drops build [OPTIONS]
+slot merkle-drops snapshot [OPTIONS]
 ```
 
 #### Required Parameters
 
-- `--name <NAME>` - Name for the merkle drop
+- `--name <NAME>` - Name for the snapshot
 - `--contract-address <CONTRACT_ADDRESS>` - NFT contract address to query
 - `--rpc-url <RPC_URL>` - Network RPC URL (e.g., https://ethereum-rpc.publicnode.com)
-- `--description <DESCRIPTION>` - Description of the merkle drop
-- `--claim-contract <CLAIM_CONTRACT>` - Claim contract address for the merkle drop
-- `--entrypoint <ENTRYPOINT>` - Entrypoint address for claiming
+- `--description <DESCRIPTION>` - Description of the snapshot
+- `--block-height <BLOCK_HEIGHT>` - Block height to query at (required for deterministic snapshots)
 
 #### Optional Parameters
 
 - `--network <NETWORK>` - Network name (e.g., ETH, BASE) (default: ETH)
-- `--block-height <BLOCK_HEIGHT>` - Block height to query at (defaults to latest)
 - `--from-id <FROM_ID>` - Starting token ID (default: 1)
 - `--to-id <TO_ID>` - Ending token ID (default: 8000)
-- `--output <OUTPUT>` - Output file path (default: merkle_drop.json)
+- `--output <OUTPUT>` - Output file path (default: snapshot.json)
 - `--delay-ms <DELAY_MS>` - Delay between RPC calls in milliseconds (default: 10)
 - `--concurrency <CONCURRENCY>` - Number of concurrent RPC requests (default: 10)
 
@@ -43,14 +41,12 @@ slot merkle-drops build [OPTIONS]
 
 ```bash
 # Query Dope Loot holders at a specific block
-slot merkle-drops build \
+slot merkle-drops snapshot \
   --name "Dope" \
   --contract-address "0x8707276DF042E89669d69A177d3DA7dC78bd8723" \
   --rpc-url "https://ethereum-rpc.publicnode.com" \
   --network "ETH" \
-  --description "Dope owners can claim their rewards" \
-  --claim-contract "0x1dCD8763c01961C2BbB5ed58C6E51F55b1378589" \
-  --entrypoint "0x1dCD8763c01961C2BbB5ed58C6E51F55b1378589" \
+  --description "Dope owners snapshot" \
   --block-height 22728943 \
   --from-id 1 \
   --to-id 8000 \
@@ -61,16 +57,14 @@ slot merkle-drops build \
 The command will:
 1. Query token IDs in parallel to find their owners (with configurable concurrency)
 2. Build a map of owner addresses to token IDs
-3. Generate a merkle tree using Poseidon hash (root is displayed in console)
-4. Output a JSON file with metadata and snapshot data:
+3. Output a JSON file with metadata and snapshot data:
    ```json
    {
      "name": "Dope",
      "network": "ETH",
-     "description": "Dope owners can claim their rewards",
-     "claim_contract": "0x1dCD8763c01961C2BbB5ed58C6E51F55b1378589",
-     "entrypoint": "0x1dCD8763c01961C2BbB5ed58C6E51F55b1378589",
-     "merkle_root": "0x8f7c9e2b1a5d4e8f3c6b9a2d7e1f4c8b5e9a3d7c1f8e4b2a6d9c3f7e1a5b8d2c6f",
+     "description": "Dope owners snapshot",
+     "contract_address": "0x8707276DF042E89669d69A177d3DA7dC78bd8723",
+     "block_height": 22728943,
      "snapshot": [
        ["0xAddress1", [1, 2, 3]],
        ["0xAddress2", [4, 5, 6]]
@@ -78,7 +72,7 @@ The command will:
    }
    ```
 
-The output file can be directly used with `slot merkle-drops create json --file <output>`
+The output file can be used with `slot merkle-drops create --json-file <output>` to create a merkle drop
 
 ### Create Merkle Drop
 


### PR DESCRIPTION
## Summary
- Renamed `merkle-drops build` command to `merkle-drops snapshot`
- Removed merkle tree construction functionality
- Command now only produces a snapshot of token holders

## Changes
- **Command rename**: `build` → `snapshot` (alias changed from `b` to `s`)
- **Removed merkle tree logic**: No longer builds merkle tree or calculates root
- **Simplified output**: Now outputs just the snapshot data with contract metadata
- **Updated documentation**: Reflects the new snapshot-only functionality

## Breaking Changes
- Users previously using `slot merkle-drops build` must now use `slot merkle-drops snapshot`
- Output JSON structure changed:
  - Removed: `claim_contract`, `entrypoint`, `merkle_root`
  - Added: `contract_address`, `block_height`
- Default output filename changed from `merkle_drop.json` to `snapshot.json`

## Test Plan
- [ ] Command runs successfully with new `snapshot` name
- [ ] Snapshot data is correctly generated without merkle tree
- [ ] Documentation accurately describes the new functionality

🤖 Generated with [Claude Code](https://claude.ai/code)