### PR TITLE
fix(teams): standardize balance output to 6 decimals

### DIFF
--- a/cli/src/command/teams/balance.rs
+++ b/cli/src/command/teams/balance.rs
@@ -46,7 +46,7 @@ impl BalanceArgs {
 
 fn format_usd(credits: i64) -> String {
     let dollars = credits as f64 / 100.0 / 1e6;
-    format!("${:.2}", dollars)
+    format!("${:.6}", dollars)
 }
 
 fn format_strk(strk: i64) -> String {


### PR DESCRIPTION
## Summary
- Print USD with 6 decimals to match STRK; both fields are stored as 6-decimal-precision integers in the DB.
- Avoids hiding sub-cent balances behind the previous 2-decimal rounding.

## Test plan
- [ ] `slot teams <name> balance` shows both rows with 6 decimals (e.g. `$0.195100`, `10.000000`)