### PR TITLE
fix(paymaster): show STRK budget total in info output

### DIFF
--- a/cli/src/command/paymaster/info.rs
+++ b/cli/src/command/paymaster/info.rs
@@ -73,18 +73,14 @@ impl InfoArgs {
                 );
 
                 println!("\n💰 Budget:");
-                if budget_formatted > 0.0 {
-                    match paymaster.budget_fee_unit {
-                        PaymasterBudgetFeeUnit::CREDIT => {
-                            println!("  • Total: ${:.2} USD", budget_formatted * 0.01)
-                        }
-                        PaymasterBudgetFeeUnit::STRK => {
-                            println!("  • Total: {:.2} STRK", budget_formatted)
-                        }
-                        _ => println!("  • Total: NONE (Please Top Up)"),
+                match paymaster.budget_fee_unit {
+                    PaymasterBudgetFeeUnit::CREDIT => {
+                        println!("  • Total: ${:.2} USD", budget_formatted * 0.01)
                     }
-                } else {
-                    println!("  • Total: NONE (Please Top Up)");
+                    PaymasterBudgetFeeUnit::STRK => {
+                        println!("  • Total: {:.2} STRK", budget_formatted)
+                    }
+                    _ => println!("  • Total: Unsupported"),
                 }
 
                 // Only display the relevant fee type based on budget unit

--- a/cli/src/command/paymaster/info.rs
+++ b/cli/src/command/paymaster/info.rs
@@ -73,13 +73,16 @@ impl InfoArgs {
                 );
 
                 println!("\n💰 Budget:");
-                let usd_equivalent = match paymaster.budget_fee_unit {
-                    PaymasterBudgetFeeUnit::CREDIT => budget_formatted * 0.01, // 100 credit = 1 USD
-                    _ => 0.0,
-                };
-
-                if usd_equivalent > 0.0 {
-                    println!("  • Total: ${:.2} USD", usd_equivalent);
+                if budget_formatted > 0.0 {
+                    match paymaster.budget_fee_unit {
+                        PaymasterBudgetFeeUnit::CREDIT => {
+                            println!("  • Total: ${:.2} USD", budget_formatted * 0.01)
+                        }
+                        PaymasterBudgetFeeUnit::STRK => {
+                            println!("  • Total: {:.2} STRK", budget_formatted)
+                        }
+                        _ => println!("  • Total: NONE (Please Top Up)"),
+                    }
                 } else {
                     println!("  • Total: NONE (Please Top Up)");
                 }


### PR DESCRIPTION
## Summary
- `slot paymaster <name> info` was reporting `Total: NONE (Please Top Up)` for STRK-denominated paymasters even when they had a non-zero budget.
- Root cause: the Total branch in `info.rs` only matched `PaymasterBudgetFeeUnit::CREDIT` and fell through to `0.0` for STRK, then hit the empty-budget message. The Spent block right below already branched on both units correctly — Total now mirrors that.

## Test plan
- [ ] Reproduce: `slot paymaster <strk-pm> info` now shows `Total: X.XX STRK` (e.g., `5.00 STRK`) instead of NONE.
- [ ] Regression: USD-denominated paymasters still render `Total: $X.XX USD`.
- [ ] An actually-empty paymaster still shows `Total: NONE (Please Top Up)`.