### PR TITLE
fix(paymaster): render STRK fees for STRK-budget paymasters

### DIFF
--- a/cli/src/command/paymaster/stats.rs
+++ b/cli/src/command/paymaster/stats.rs
@@ -4,6 +4,7 @@ use clap::Args;
 use slot::api::Client;
 use slot::credential::Credentials;
 use slot::graphql::paymaster::paymaster_stats;
+use slot::graphql::paymaster::paymaster_stats::PaymasterBudgetFeeUnit;
 use slot::graphql::paymaster::PaymasterStats;
 use slot::graphql::GraphQLQuery;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -76,15 +77,31 @@ impl StatsArgs {
             println!("  • TPS: {:.4}", tps);
         }
 
-        println!("\n💰 Fees (USD):");
-        println!(
-            "  • Total ({}): ${:.2}",
-            self.last,
-            stats.total_usd_fees.unwrap_or(0.0)
-        );
-        println!("  • Average: ${:.6}", stats.avg_usd_fee.unwrap_or(0.0));
-        println!("  • Minimum: ${:.6}", stats.min_usd_fee.unwrap_or(0.0));
-        println!("  • Maximum: ${:.6}", stats.max_usd_fee.unwrap_or(0.0));
+        let unit = data.paymaster.as_ref().map(|p| &p.budget_fee_unit);
+        match unit {
+            Some(PaymasterBudgetFeeUnit::STRK) => {
+                println!("\n💰 Fees (STRK):");
+                println!(
+                    "  • Total ({}): {:.2} STRK",
+                    self.last,
+                    stats.total_strk_fees.unwrap_or(0.0)
+                );
+                println!("  • Average: {:.6} STRK", stats.avg_strk_fee.unwrap_or(0.0));
+                println!("  • Minimum: {:.6} STRK", stats.min_strk_fee.unwrap_or(0.0));
+                println!("  • Maximum: {:.6} STRK", stats.max_strk_fee.unwrap_or(0.0));
+            }
+            _ => {
+                println!("\n💰 Fees (USD):");
+                println!(
+                    "  • Total ({}): ${:.2}",
+                    self.last,
+                    stats.total_usd_fees.unwrap_or(0.0)
+                );
+                println!("  • Average: ${:.6}", stats.avg_usd_fee.unwrap_or(0.0));
+                println!("  • Minimum: ${:.6}", stats.min_usd_fee.unwrap_or(0.0));
+                println!("  • Maximum: ${:.6}", stats.max_usd_fee.unwrap_or(0.0));
+            }
+        }
 
         println!("\n👥 Users:");
         println!("  • Unique Users: {}", stats.unique_users);

--- a/cli/src/command/paymaster/transactions.rs
+++ b/cli/src/command/paymaster/transactions.rs
@@ -5,7 +5,7 @@ use slot::api::Client;
 use slot::credential::Credentials;
 use slot::graphql::paymaster::paymaster_transactions;
 use slot::graphql::paymaster::paymaster_transactions::{
-    PaymasterTransactionFilter, PaymasterTransactionOrder,
+    PaymasterBudgetFeeUnit, PaymasterTransactionFilter, PaymasterTransactionOrder,
 };
 use slot::graphql::paymaster::PaymasterTransactions;
 use slot::graphql::GraphQLQuery;
@@ -45,7 +45,7 @@ pub struct TransactionDisplay {
     pub transaction_hash: String,
     pub executed_at: String,
     pub status: String,
-    pub usd_fee: String,
+    pub fee: String,
 }
 
 impl TransactionArgs {
@@ -108,6 +108,11 @@ impl TransactionArgs {
         let client = Client::new_with_token(credentials.access_token);
         let data: paymaster_transactions::ResponseData = client.query(&request_body).await?;
 
+        let is_strk = matches!(
+            data.paymaster.as_ref().map(|p| &p.budget_fee_unit),
+            Some(PaymasterBudgetFeeUnit::STRK)
+        );
+
         let transactions = data.paymaster_transactions;
 
         if transactions.is_empty() {
@@ -121,7 +126,6 @@ impl TransactionArgs {
         }
 
         // Convert to display format
-        // Convert to display format
         let display_transactions: Vec<TransactionDisplay> = transactions
             .into_iter()
             .map(|t| TransactionDisplay {
@@ -132,7 +136,11 @@ impl TransactionArgs {
                     paymaster_transactions::ActivityStatus::FAILED => "REVERTED".to_string(),
                     _ => format!("{:?}", t.status), // Fallback for any other status values
                 },
-                usd_fee: format!("${:.4}", t.usd_fee),
+                fee: if is_strk {
+                    format!("{:.4} STRK", t.strk_fee)
+                } else {
+                    format!("${:.4}", t.usd_fee)
+                },
             })
             .collect();
 
@@ -143,7 +151,7 @@ impl TransactionArgs {
         );
         println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
 
-        print_transactions_table(&display_transactions);
+        print_transactions_table(&display_transactions, is_strk);
 
         Ok(())
     }
@@ -188,26 +196,34 @@ fn format_relative_time(executed_at: &str) -> String {
     format!("{}w ago", weeks)
 }
 
-pub fn print_transactions_table(transactions: &[TransactionDisplay]) {
+pub fn print_transactions_table(transactions: &[TransactionDisplay], is_strk: bool) {
     if transactions.is_empty() {
         return;
     }
 
+    let fee_header = if is_strk { "STRK Fee" } else { "USD Fee" };
+    let fee_width = if is_strk { 16 } else { 12 };
+
     // Print header - adjusted widths for full hash and relative time
     println!(
-        "{:<66} {:<12} {:<12} {:<12}",
-        "Transaction Hash", "Executed", "Status", "USD Fee"
+        "{:<66} {:<12} {:<12} {:<width$}",
+        "Transaction Hash",
+        "Executed",
+        "Status",
+        fee_header,
+        width = fee_width,
     );
     println!("{}", "─".repeat(110));
 
     // Print transactions
     for transaction in transactions {
         println!(
-            "{:<66} {:<12} {:<12} {:<12}",
+            "{:<66} {:<12} {:<12} {:<width$}",
             transaction.transaction_hash,
             transaction.executed_at,
             transaction.status,
-            transaction.usd_fee
+            transaction.fee,
+            width = fee_width,
         );
     }
 }

--- a/slot/schema.json
+++ b/slot/schema.json
@@ -35610,6 +35610,54 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "minStrkFee",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "maxStrkFee",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "avgStrkFee",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "totalStrkFees",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "totalTransactions",
               "type": {
                 "kind": "NON_NULL",
@@ -35718,6 +35766,22 @@
               "description": null,
               "isDeprecated": false,
               "name": "usdFee",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "strkFee",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,

--- a/slot/src/graphql/paymaster/stats.graphql
+++ b/slot/src/graphql/paymaster/stats.graphql
@@ -1,12 +1,19 @@
 query PaymasterStats($paymasterName: ID!, $since: Time!) {
+  paymaster(name: $paymasterName) {
+    budgetFeeUnit
+  }
   paymasterStats(paymasterName: $paymasterName, since: $since) {
     minUsdFee
     maxUsdFee
     avgUsdFee
     totalUsdFees
+    minStrkFee
+    maxStrkFee
+    avgStrkFee
+    totalStrkFees
     totalTransactions
     successfulTransactions
     revertedTransactions
     uniqueUsers
   }
-} 
+}

--- a/slot/src/graphql/paymaster/transaction.graphql
+++ b/slot/src/graphql/paymaster/transaction.graphql
@@ -7,6 +7,9 @@ query PaymasterTransactions(
   $since: Time!
   $limit: Int
 ) {
+  paymaster(name: $paymasterName) {
+    budgetFeeUnit
+  }
   paymasterTransactions(
     paymasterName: $paymasterName
     filter: $filter
@@ -17,6 +20,7 @@ query PaymasterTransactions(
     transactionHash
     status
     usdFee
+    strkFee
     executedAt
   }
 }


### PR DESCRIPTION
## Summary
- `slot paymaster transactions` and `slot paymaster stats` now branch on the paymaster's `budgetFeeUnit` and render fees in their native unit instead of always showing USD.
- Pairs with cartridge-gg/internal#4464 (the new `strkFee` / `*StrkFee*` GraphQL fields are already deployed in prod).

## Changes
- `transaction.graphql` / `stats.graphql`: request `strkFee`, the new STRK aggregates, and the paymaster's `budgetFeeUnit` for unit selection.
- `transactions.rs`: column header (`USD Fee` ↔ `STRK Fee`) and per-row formatting follow `budgetFeeUnit`.
- `stats.rs`: section title and aggregates follow `budgetFeeUnit`.
- `schema.json`: refreshed from prod (`scripts/pull_schema.sh prod`).

## Test plan
- [ ] `cargo check -p slot-cli` ✅
- [ ] `./scripts/clippy.sh` ✅
- [ ] `./scripts/rust_fmt.sh` ✅
- [ ] Run against a STRK paymaster: `slot paymaster $name transactions` shows `STRK Fee` column with `{:.4} STRK` values
- [ ] Run against a STRK paymaster: `slot paymaster $name stats` shows `💰 Fees (STRK):` block with STRK aggregates
- [ ] Run against a CREDIT (USD) paymaster: behavior unchanged
- [ ] `./scripts/e2e.sh` if you have a fresh paymaster handy

🤖 Generated with [Claude Code](https://claude.com/claude-code)